### PR TITLE
PhoneNumber.__eq__

### DIFF
--- a/python/phonenumbers/phonenumber.py
+++ b/python/phonenumbers/phonenumber.py
@@ -165,13 +165,15 @@ class PhoneNumber(object):
             self.preferred_domestic_carrier_code = other.preferred_domestic_carrier_code
 
     def __eq__(self, other):
-        return (self.country_code == other.country_code and
-                self.national_number == other.national_number and
-                self.extension == other.extension and
-                self.italian_leading_zero == other.italian_leading_zero and
-                self.raw_input == other.raw_input and
-                self.country_code_source == other.country_code_source and
-                self.preferred_domestic_carrier_code == other.preferred_domestic_carrier_code)
+        if isinstance(other, PhoneNumber):
+            return (self.country_code == other.country_code and
+                    self.national_number == other.national_number and
+                    self.extension == other.extension and
+                    self.italian_leading_zero == other.italian_leading_zero and
+                    self.raw_input == other.raw_input and
+                    self.country_code_source == other.country_code_source and
+                    self.preferred_domestic_carrier_code == other.preferred_domestic_carrier_code)
+        return False
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/python/tests/testphonenumber.py
+++ b/python/tests/testphonenumber.py
@@ -40,6 +40,15 @@ class PhoneNumberTest(unittest.TestCase):
         numberB = PhoneNumber(country_code=1, national_number=6502530000L)
         self.assertEquals(numberA, numberB)
 
+    def test_non_equal_with_different_object(self):
+        numberA = PhoneNumber()
+        numberA.country_code = 1
+        numberA.national_number = 6502530000L
+        numberA.preferred_domestic_carrier_code = ""
+        self.assertNotEqual(numberA, None)
+        self.assertNotEqual(numberA, "")
+        self.assertNotEqual(numberA, 1)
+
     def test_equal_with_italian_leading_zero_set_to_default(self):
         numberA = PhoneNumber()
         numberA.country_code = 1


### PR DESCRIPTION
I've noticed that `PhoneNumber.__eq__` throws error when it is being compared with an object with NoneType, so I've added a small update and a test.

Thanks for the awesome port, btw. SQLAlchemy custom types with python-phonenumbers make me one happy programmer.
