### PR TITLE
Update python/phonenumbers/phonenumberutil.py

### DIFF
--- a/python/phonenumbers/phonenumberutil.py
+++ b/python/phonenumbers/phonenumberutil.py
@@ -2072,7 +2072,7 @@ def _check_region_for_parsing(number, default_region):
     return True
 
 
-def parse(number, region, keep_raw_input=False,
+def parse(number, region=None, keep_raw_input=False,
           numobj=None, _check_region=True):
     """Parse a string and return a corresponding PhoneNumber object.
 


### PR DESCRIPTION
seems default region for parse method is None.
