### PR TITLE
Add 63998 prefix for Smart in the Philippines.

### DIFF
--- a/resources/carrier/en/63.txt
+++ b/resources/carrier/en/63.txt
@@ -46,4 +46,5 @@
 63947|Smart
 63948|Smart
 63949|Smart
+63998|Smart
 63999|Smart


### PR DESCRIPTION
This was causing a bug in our stuff.
