### PR TITLE
Add Python 3 trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,5 +52,7 @@ distutils.core.setup(name='phonenumbers',
                                   'License :: OSI Approved :: Apache Software License',
                                   'Operating System :: OS Independent',
                                   'Topic :: Communications :: Telephony',
+                                  'Programming Language :: Python',
+                                  'Programming Language :: Python :: 3'
                                   ],
                      )


### PR DESCRIPTION
This adds the Python 2 and 3 trove classifier so that PyPI and tools such as caniusepython3 know that both Python 2 and 3 are supported.
