### PR TITLE
Make all optional PhoneNumber fields default to None.

### DIFF
--- a/python/phonenumbers/__init__.py
+++ b/python/phonenumbers/__init__.py
@@ -6,7 +6,7 @@ Examples of use:
 >>> from phonenumbers.util import prnt  # equivalent to Py3k print()
 >>> x = phonenumbers.parse("+442083661177", None)
 >>> prnt(x)
-Country Code: 44 National Number: 2083661177 Leading Zero(s): False
+Country Code: 44 National Number: 2083661177
 >>> type(x)
 <class 'phonenumbers.phonenumber.PhoneNumber'>
 >>> str(phonenumbers.format_number(x, phonenumbers.PhoneNumberFormat.NATIONAL))
@@ -17,7 +17,7 @@ Country Code: 44 National Number: 2083661177 Leading Zero(s): False
 '+442083661177'
 >>> y = phonenumbers.parse("020 8366 1177", "GB")
 >>> prnt(y)
-Country Code: 44 National Number: 2083661177 Leading Zero(s): False
+Country Code: 44 National Number: 2083661177
 >>> x == y
 True
 >>>

--- a/python/phonenumbers/phonenumber.py
+++ b/python/phonenumbers/phonenumber.py
@@ -57,7 +57,7 @@ class PhoneNumber(UnicodeMixin):
                  country_code=None,
                  national_number=None,
                  extension=None,
-                 italian_leading_zero=False,
+                 italian_leading_zero=None,
                  number_of_leading_zeros=None,
                  raw_input=None,
                  country_code_source=None,
@@ -119,8 +119,18 @@ class PhoneNumber(UnicodeMixin):
         #
         # Clients who use the parsing functionality of the i18n phone number
         # libraries will have these fields set if necessary automatically.
-        self.italian_leading_zero = bool(italian_leading_zero)
-        self.number_of_leading_zeros = number_of_leading_zeros  # None or int
+        #
+        # None if not set, of type bool otherwise:
+        if italian_leading_zero is None:
+          self.italian_leading_zero = None
+        else:
+          self.italian_leading_zero = bool(italian_leading_zero)
+
+        # None if not set, of type int otherwise.
+        if number_of_leading_zeros is None:
+          self.number_of_leading_zeros = number_of_leading_zeros
+        else:
+          self.number_of_leading_zeros = int(number_of_leading_zeros)
 
         # The next few fields are non-essential fields for a phone number.
         # They retain extra information about the form the phone number was
@@ -156,7 +166,7 @@ class PhoneNumber(UnicodeMixin):
         self.country_code = None
         self.national_number = None
         self.extension = None
-        self.italian_leading_zero = False
+        self.italian_leading_zero = None
         self.number_of_leading_zeros = None
         self.raw_input = None
         self.country_code_source = None

--- a/python/phonenumbers/phonenumber.py
+++ b/python/phonenumbers/phonenumber.py
@@ -122,15 +122,15 @@ class PhoneNumber(UnicodeMixin):
         #
         # None if not set, of type bool otherwise:
         if italian_leading_zero is None:
-          self.italian_leading_zero = None
+            self.italian_leading_zero = None
         else:
-          self.italian_leading_zero = bool(italian_leading_zero)
+            self.italian_leading_zero = bool(italian_leading_zero)
 
         # None if not set, of type int otherwise.
         if number_of_leading_zeros is None:
-          self.number_of_leading_zeros = number_of_leading_zeros
+            self.number_of_leading_zeros = number_of_leading_zeros
         else:
-          self.number_of_leading_zeros = int(number_of_leading_zeros)
+            self.number_of_leading_zeros = int(number_of_leading_zeros)
 
         # The next few fields are non-essential fields for a phone number.
         # They retain extra information about the form the phone number was

--- a/python/phonenumbers/phonenumber.py
+++ b/python/phonenumbers/phonenumber.py
@@ -197,7 +197,7 @@ class PhoneNumber(UnicodeMixin):
         return (self.country_code == other.country_code and
                 self.national_number == other.national_number and
                 self.extension == other.extension and
-                self.italian_leading_zero == other.italian_leading_zero and
+                bool(self.italian_leading_zero) == bool(other.italian_leading_zero) and
                 self.number_of_leading_zeros == other.number_of_leading_zeros and
                 self.raw_input == other.raw_input and
                 self.country_code_source == other.country_code_source and
@@ -241,7 +241,7 @@ class FrozenPhoneNumber(PhoneNumber, ImmutableMixin):
         return hash((self.country_code,
                      self.national_number,
                      self.extension,
-                     self.italian_leading_zero,
+                     bool(self.italian_leading_zero),
                      self.number_of_leading_zeros,
                      self.raw_input,
                      self.country_code_source,

--- a/python/tests/examplenumberstest.py
+++ b/python/tests/examplenumberstest.py
@@ -234,7 +234,7 @@ class ExampleNumbersTest(unittest.TestCase):
         # Some metadata is blank; check that we cope with this.
         # Example: MH (+692)
         number = phonenumberutil.parse("+6927654321", "US")
-        self.assertEqual("Country Code: 692 National Number: 7654321 Leading Zero(s): False", str(number))
+        self.assertEqual("Country Code: 692 National Number: 7654321", str(number))
 
     def testMetadataPrint(self):
         for callingCode in PhoneMetadata._region_available.keys():

--- a/python/tests/phonenumbermatchertest.py
+++ b/python/tests/phonenumbermatchertest.py
@@ -96,7 +96,7 @@ class PhoneNumberMatchTest(unittest.TestCase):
         # Python version extra test
         self.assertEqual("PhoneNumberMatch(start=10, raw_string='1 800 234 45 67', "
                          "numobj=PhoneNumber(country_code=None, national_number=None, extension=None, "
-                         "italian_leading_zero=False, number_of_leading_zeros=None, "
+                         "italian_leading_zero=None, number_of_leading_zeros=None, "
                          "country_code_source=None, preferred_domestic_carrier_code=None))", repr(match))
 
 

--- a/python/tests/phonenumbertest.py
+++ b/python/tests/phonenumbertest.py
@@ -38,18 +38,6 @@ class PhoneNumberTest(unittest.TestCase):
         numberB = PhoneNumber(country_code=1, national_number=6502530000)
         self.assertEqual(numberA, numberB)
 
-    def test_equal_with_italian_leading_zero_set_to_default(self):
-        numberA = PhoneNumber()
-        numberA.country_code = 1
-        numberA.national_number = to_long(6502530000)
-        numberA.italian_leading_zero = False
-        numberB = PhoneNumber()
-        numberB.country_code = 1
-        numberB.national_number = to_long(6502530000)
-        # These should still be equal, since the default value for this field
-        # is false.
-        self.assertEqual(numberA, numberB)
-
     def test_equal_with_country_code_source_set(self):
         numberA = PhoneNumber()
         numberA.raw_input = "+1 650 253 00 00"

--- a/python/tests/phonenumbertest.py
+++ b/python/tests/phonenumbertest.py
@@ -38,6 +38,18 @@ class PhoneNumberTest(unittest.TestCase):
         numberB = PhoneNumber(country_code=1, national_number=6502530000)
         self.assertEqual(numberA, numberB)
 
+    def test_equal_with_italian_leading_zero_set_to_default(self):
+        numberA = PhoneNumber()
+        numberA.country_code = 1
+        numberA.national_number = to_long(6502530000)
+        numberA.italian_leading_zero = False
+        numberB = PhoneNumber()
+        numberB.country_code = 1
+        numberB.national_number = to_long(6502530000)
+        # These should still be equal, since the default value for this field
+        # is false.
+        self.assertEqual(numberA, numberB)
+
     def test_equal_with_country_code_source_set(self):
         numberA = PhoneNumber()
         numberA.raw_input = "+1 650 253 00 00"

--- a/python/tests/phonenumberutiltest.py
+++ b/python/tests/phonenumberutiltest.py
@@ -617,10 +617,10 @@ class PhoneNumberUtilTest(TestMetadataTestCase):
                          phonenumbers.format_national_number_with_preferred_carrier_code(arNumber, ""))
         # Python version extra test: check string conversion with preferred carrier code
         self.assertEqual('Country Code: 54 National Number: 91234125678 '
-                         'Leading Zero(s): False Preferred Domestic Carrier Code: 19',
+                         'Preferred Domestic Carrier Code: 19',
                          str(arNumber))
         self.assertEqual("PhoneNumber(country_code=54, national_number=91234125678, extension=None, "
-                         "italian_leading_zero=False, number_of_leading_zeros=None, "
+                         "italian_leading_zero=None, number_of_leading_zeros=None, "
                          "country_code_source=None, preferred_domestic_carrier_code='19')",
                          repr(arNumber))
         # When the preferred_domestic_carrier_code is present (even when it
@@ -1486,7 +1486,7 @@ class PhoneNumberUtilTest(TestMetadataTestCase):
             self.assertEqual(strippedNumber, numberToFill,
                              msg="Did not strip off the country calling code correctly.")
             # Python version extra test covering string conversion with country_code_source present
-            self.assertEqual("Country Code: 1 National Number: None Leading Zero(s): False Country Code Source: 5",
+            self.assertEqual("Country Code: 1 National Number: None Country Code Source: 5",
                              str(number))
         except NumberParseException:
             e = sys.exc_info()[1]


### PR DESCRIPTION
The fields italian_leading_zero and number_of_leading_zeros currently behave slightly different from other fields in class PhoneNumber and from their corresponding fields in libphonenumber implementations that use protocol buffers.

These changes will make them both default to None and coerce them both to bool and int respectively when they're set, to bring them in line with how other fields are treated and other implementations work.

This will help interoperability with other implementations.
