### PR TITLE
Add support of rfc5733

### DIFF
--- a/python/phonenumbers/phonenumberutil.py
+++ b/python/phonenumbers/phonenumberutil.py
@@ -32,7 +32,7 @@ import re
 
 from .re_util import fullmatch   # Extra regexp function; see README
 from .util import UnicodeMixin, u, unicod, prnt, to_long
-from .util import U_EMPTY_STRING, U_SPACE, U_DASH, U_TILDE, U_ZERO, U_SEMICOLON
+from .util import U_EMPTY_STRING, U_SPACE, U_DASH, U_TILDE, U_ZERO, U_SEMICOLON, U_DOT, U_X_LOWER
 from .unicode_util import digit as unicode_digit
 
 # Data class definitions
@@ -366,6 +366,7 @@ class PhoneNumberFormat(object):
     INTERNATIONAL = 1
     NATIONAL = 2
     RFC3966 = 3
+    RFC5733 = 4  # https://tools.ietf.org/html/rfc5733#section-2.5
 
 
 class PhoneNumberType(object):
@@ -1463,6 +1464,14 @@ def _prefix_number_with_country_calling_code(country_code, num_format, formatted
         return _PLUS_SIGN + unicod(country_code) + U_SPACE + formatted_number
     elif num_format == PhoneNumberFormat.RFC3966:
         return _RFC3966_PREFIX + _PLUS_SIGN + unicod(country_code) + U_DASH + formatted_number
+    elif num_format == PhoneNumberFormat.RFC5733:
+        splits = formatted_number.split(_DEFAULT_EXTN_PREFIX)
+        result = _PLUS_SIGN + unicod(country_code) + U_DOT + re.sub(NON_DIGITS_PATTERN,
+                                                                    U_EMPTY_STRING,
+                                                                    splits[0])
+        if len(splits) > 1:
+            result += U_X_LOWER + splits[1]
+        return result
     else:
         return formatted_number
 

--- a/python/phonenumbers/util.py
+++ b/python/phonenumbers/util.py
@@ -102,6 +102,7 @@ else:  # pragma no cover
 U_EMPTY_STRING = unicod("")
 U_SPACE = unicod(" ")
 U_DASH = unicod("-")
+U_DOT = unicod(".")
 U_TILDE = unicod("~")
 U_PLUS = unicod("+")
 U_STAR = unicod("*")

--- a/python/tests/phonenumberutiltest.py
+++ b/python/tests/phonenumberutiltest.py
@@ -354,6 +354,7 @@ class PhoneNumberUtilTest(TestMetadataTestCase):
         self.assertEqual("900 253 0000", phonenumbers.format_number(US_PREMIUM, PhoneNumberFormat.NATIONAL))
         self.assertEqual("+1 900 253 0000", phonenumbers.format_number(US_PREMIUM, PhoneNumberFormat.INTERNATIONAL))
         self.assertEqual("tel:+1-900-253-0000", phonenumbers.format_number(US_PREMIUM, PhoneNumberFormat.RFC3966))
+        self.assertEqual("+1.9002530000", phonenumbers.format_number(US_PREMIUM, PhoneNumberFormat.RFC5733))
         # Numbers with all zeros in the national number part will be formatted by using the raw_input
         # if that is available no matter which format is specified.
         self.assertEqual("000-000-0000",
@@ -376,6 +377,7 @@ class PhoneNumberUtilTest(TestMetadataTestCase):
         self.assertEqual("030/1234", phonenumbers.format_number(deNumber, PhoneNumberFormat.NATIONAL))
         self.assertEqual("+49 30/1234", phonenumbers.format_number(deNumber, PhoneNumberFormat.INTERNATIONAL))
         self.assertEqual("tel:+49-30-1234", phonenumbers.format_number(deNumber, PhoneNumberFormat.RFC3966))
+        self.assertEqual("+49.301234", phonenumbers.format_number(deNumber, PhoneNumberFormat.RFC5733))
 
         deNumber.clear()
         deNumber.country_code = 49
@@ -789,6 +791,9 @@ class PhoneNumberUtilTest(TestMetadataTestCase):
         self.assertEqual("tel:+1-650-253-0000", phonenumbers.format_by_pattern(US_NUMBER,
                                                                                PhoneNumberFormat.RFC3966,
                                                                                newNumberFormats))
+        self.assertEqual("+1.6502530000", phonenumbers.format_by_pattern(US_NUMBER,
+                                                                         PhoneNumberFormat.RFC5733,
+                                                                         newNumberFormats))
 
         # $NP is set to '1' for the US. Here we check that for other NANPA
         # countries the US rules are followed.
@@ -853,6 +858,7 @@ class PhoneNumberUtilTest(TestMetadataTestCase):
         self.assertEqual("03-331 6005 ext. 1234", phonenumbers.format_number(nzNumber, PhoneNumberFormat.NATIONAL))
         # Uses RFC 3966 syntax.
         self.assertEqual("tel:+64-3-331-6005;ext=1234", phonenumbers.format_number(nzNumber, PhoneNumberFormat.RFC3966))
+        self.assertEqual("+64.33316005x1234", phonenumbers.format_number(nzNumber, PhoneNumberFormat.RFC5733))
         # Extension prefix overridden in the territory information for the US:
         usNumberWithExtension = PhoneNumber()
         usNumberWithExtension.merge_from(US_NUMBER)


### PR DESCRIPTION
Domain registry use a telephone number format described in rfc5733.

It could be great if registrar can use this library to validate their client phone number

see https://tools.ietf.org/html/rfc5733#section-2.5
