### PR TITLE
Using a json file to add country name to PhoneNumber object returned by parse

### DIFF
--- a/python/phonenumbers/DialerCodes.json
+++ b/python/phonenumbers/DialerCodes.json
@@ -1,0 +1,914 @@
+{
+        "216": {
+                "code": "TN",
+                "name": "Tunisia"
+        },
+        "": {
+                "code": "AX",
+                "name": "land Islands"
+        },
+        "1268": {
+                "code": "AG",
+                "name": "Antigua and Barbuda"
+        },
+        "212": {
+                "code": "MA",
+                "name": "Morocco"
+        },
+        "213": {
+                "code": "DZ",
+                "name": "Algeria"
+        },
+        "264": {
+                "code": "NA",
+                "name": "Namibia"
+        },
+        "218": {
+                "code": "LY",
+                "name": "Libyan Arab Jamahiriya"
+        },
+        "43": {
+                "code": "AT",
+                "name": "Austria"
+        },
+        "227": {
+                "code": "NE",
+                "name": "Niger"
+        },
+        "40": {
+                "code": "RO",
+                "name": "Romania"
+        },
+        "90": {
+                "code": "TR",
+                "name": "Turkey"
+        },
+        "225": {
+                "code": "CI",
+                "name": "Cote d'Ivoire"
+        },
+        "1 284": {
+                "code": "VG",
+                "name": "Virgin Islands, British"
+        },
+        "692": {
+                "code": "MH",
+                "name": "Marshall Islands"
+        },
+        "690": {
+                "code": "TK",
+                "name": "Tokelau"
+        },
+        "92": {
+                "code": "PK",
+                "name": "Pakistan"
+        },
+        "20": {
+                "code": "EG",
+                "name": "Egypt"
+        },
+        "1 784": {
+                "code": "VC",
+                "name": "Saint Vincent and the Grenadines"
+        },
+        "95": {
+                "code": "MM",
+                "name": "Myanmar"
+        },
+        "94": {
+                "code": "LK",
+                "name": "Sri Lanka"
+        },
+        "995": {
+                "code": "GE",
+                "name": "Georgia"
+        },
+        "994": {
+                "code": "AZ",
+                "name": "Azerbaijan"
+        },
+        "996": {
+                "code": "KG",
+                "name": "Kyrgyzstan"
+        },
+        "678": {
+                "code": "VU",
+                "name": "Vanuatu"
+        },
+        "679": {
+                "code": "FJ",
+                "name": "Fiji"
+        },
+        "993": {
+                "code": "TM",
+                "name": "Turkmenistan"
+        },
+        "992": {
+                "code": "TJ",
+                "name": "Tajikistan"
+        },
+        "674": {
+                "code": "NR",
+                "name": "Nauru"
+        },
+        "675": {
+                "code": "PG",
+                "name": "Papua New Guinea"
+        },
+        "676": {
+                "code": "TO",
+                "name": "Tonga"
+        },
+        "677": {
+                "code": "SB",
+                "name": "Solomon Islands"
+        },
+        "670": {
+                "code": "TL",
+                "name": "Timor-Leste"
+        },
+        "998": {
+                "code": "UZ",
+                "name": "Uzbekistan"
+        },
+        "672": {
+                "code": "NF",
+                "name": "Norfolk Island"
+        },
+        "673": {
+                "code": "BN",
+                "name": "Brunei Darussalam"
+        },
+        "263": {
+                "code": "ZW",
+                "name": "Zimbabwe"
+        },
+        "262": {
+                "code": "RE",
+                "name": "R\u00e9union"
+        },
+        "261": {
+                "code": "MG",
+                "name": "Madagascar"
+        },
+        "260": {
+                "code": "ZM",
+                "name": "Zambia"
+        },
+        "267": {
+                "code": "BW",
+                "name": "Botswana"
+        },
+        "266": {
+                "code": "LS",
+                "name": "Lesotho"
+        },
+        "265": {
+                "code": "MW",
+                "name": "Malawi"
+        },
+        "1 849": {
+                "code": "DO",
+                "name": "Dominican Republic"
+        },
+        "269": {
+                "code": "KM",
+                "name": "Comoros"
+        },
+        "268": {
+                "code": "SZ",
+                "name": "Swaziland"
+        },
+        "58": {
+                "code": "VE",
+                "name": "Venezuela, Bolivarian Republic of"
+        },
+        "55": {
+                "code": "BR",
+                "name": "Brazil"
+        },
+        "54": {
+                "code": "AR",
+                "name": "Argentina"
+        },
+        "57": {
+                "code": "CO",
+                "name": "Colombia"
+        },
+        "56": {
+                "code": "CL",
+                "name": "Chile"
+        },
+        "51": {
+                "code": "PE",
+                "name": "Peru"
+        },
+        "258": {
+                "code": "MZ",
+                "name": "Mozambique"
+        },
+        "53": {
+                "code": "CU",
+                "name": "Cuba"
+        },
+        "52": {
+                "code": "MX",
+                "name": "Mexico"
+        },
+        "537": {
+                "code": "CY",
+                "name": "Cyprus"
+        },
+        "378": {
+                "code": "SM",
+                "name": "San Marino"
+        },
+        "298": {
+                "code": "FO",
+                "name": "Faroe Islands"
+        },
+        "299": {
+                "code": "GL",
+                "name": "Greenland"
+        },
+        "371": {
+                "code": "LV",
+                "name": "Latvia"
+        },
+        "297": {
+                "code": "AW",
+                "name": "Aruba"
+        },
+        "373": {
+                "code": "MD",
+                "name": "Moldova, Republic of"
+        },
+        "372": {
+                "code": "EE",
+                "name": "Estonia"
+        },
+        "375": {
+                "code": "BY",
+                "name": "Belarus"
+        },
+        "374": {
+                "code": "AM",
+                "name": "Armenia"
+        },
+        "377": {
+                "code": "MC",
+                "name": "Monaco"
+        },
+        "291": {
+                "code": "ER",
+                "name": "Eritrea"
+        },
+        "591": {
+                "code": "BO",
+                "name": "Bolivia, Plurinational State of"
+        },
+        "590": {
+                "code": "MF",
+                "name": "Saint Martin"
+        },
+        "593": {
+                "code": "EC",
+                "name": "Ecuador"
+        },
+        "595": {
+                "code": "PY",
+                "name": "Paraguay"
+        },
+        "594": {
+                "code": "GF",
+                "name": "French Guiana"
+        },
+        "1 767": {
+                "code": "DM",
+                "name": "Dominica"
+        },
+        "596": {
+                "code": "MQ",
+                "name": "Martinique"
+        },
+        "599": {
+                "code": "AN",
+                "name": "Netherlands Antilles"
+        },
+        "598": {
+                "code": "UY",
+                "name": "Uruguay"
+        },
+        "1 649": {
+                "code": "TC",
+                "name": "Turks and Caicos Islands"
+        },
+        "82": {
+                "code": "KR",
+                "name": "Korea, Republic of"
+        },
+        "81": {
+                "code": "JP",
+                "name": "Japan"
+        },
+        "86": {
+                "code": "CN",
+                "name": "China"
+        },
+        "84": {
+                "code": "VN",
+                "name": "Viet Nam"
+        },
+        "379": {
+                "code": "VA",
+                "name": "Holy See (Vatican City State)"
+        },
+        "1 242": {
+                "code": "BS",
+                "name": "Bahamas"
+        },
+        "1 246": {
+                "code": "BB",
+                "name": "Barbados"
+        },
+        "27": {
+                "code": "ZA",
+                "name": "South Africa"
+        },
+        "7": {
+                "code": "RU",
+                "name": "Russia"
+        },
+        "421": {
+                "code": "SK",
+                "name": "Slovakia"
+        },
+        "420": {
+                "code": "CZ",
+                "name": "Czech Republic"
+        },
+        "423": {
+                "code": "LI",
+                "name": "Liechtenstein"
+        },
+        "7 7": {
+                "code": "KZ",
+                "name": "Kazakhstan"
+        },
+        "963": {
+                "code": "SY",
+                "name": "Syrian Arab Republic"
+        },
+        "976": {
+                "code": "MN",
+                "name": "Mongolia"
+        },
+        "856": {
+                "code": "LA",
+                "name": "Lao People's Democratic Republic"
+        },
+        "245": {
+                "code": "GW",
+                "name": "Guinea-Bissau"
+        },
+        "244": {
+                "code": "AO",
+                "name": "Angola"
+        },
+        "382": {
+                "code": "ME",
+                "name": "Montenegro"
+        },
+        "246": {
+                "code": "IO",
+                "name": "British Indian Ocean Territory"
+        },
+        "241": {
+                "code": "GA",
+                "name": "Gabon"
+        },
+        "240": {
+                "code": "GQ",
+                "name": "Equatorial Guinea"
+        },
+        "386": {
+                "code": "SI",
+                "name": "Slovenia"
+        },
+        "242": {
+                "code": "CG",
+                "name": "Congo"
+        },
+        "850": {
+                "code": "KP",
+                "name": "Korea, Democratic People's Republic of"
+        },
+        "1 671": {
+                "code": "GU",
+                "name": "Guam"
+        },
+        "1 670": {
+                "code": "MP",
+                "name": "Northern Mariana Islands"
+        },
+        "249": {
+                "code": "SD",
+                "name": "Sudan"
+        },
+        "248": {
+                "code": "SC",
+                "name": "Seychelles"
+        },
+        "380": {
+                "code": "UA",
+                "name": "Ukraine"
+        },
+        "39": {
+                "code": "IT",
+                "name": "Italy"
+        },
+        "1664": {
+                "code": "MS",
+                "name": "Montserrat"
+        },
+        "852": {
+                "code": "HK",
+                "name": "Hong Kong"
+        },
+        "1 473": {
+                "code": "GD",
+                "name": "Grenada"
+        },
+        "381": {
+                "code": "RS",
+                "name": "Serbia"
+        },
+        "33": {
+                "code": "FR",
+                "name": "France"
+        },
+        "32": {
+                "code": "BE",
+                "name": "Belgium"
+        },
+        "31": {
+                "code": "NL",
+                "name": "Netherlands"
+        },
+        "30": {
+                "code": "GR",
+                "name": "Greece"
+        },
+        "36": {
+                "code": "HU",
+                "name": "Hungary"
+        },
+        "34": {
+                "code": "ES",
+                "name": "Spain"
+        },
+        "290": {
+                "code": "SH",
+                "name": "Saint Helena, Ascension and Tristan Da Cunha"
+        },
+        "376": {
+                "code": "AD",
+                "name": "Andorra"
+        },
+        "385": {
+                "code": "HR",
+                "name": "Croatia"
+        },
+        "243": {
+                "code": "CD",
+                "name": "Congo, The Democratic Republic of the"
+        },
+        "387": {
+                "code": "BA",
+                "name": "Bosnia and Herzegovina"
+        },
+        "60": {
+                "code": "MY",
+                "name": "Malaysia"
+        },
+        "61": {
+                "code": "CC",
+                "name": "Cocos (Keeling) Islands"
+        },
+        "62": {
+                "code": "ID",
+                "name": "Indonesia"
+        },
+        "63": {
+                "code": "PH",
+                "name": "Philippines"
+        },
+        "1 264": {
+                "code": "AI",
+                "name": "Anguilla"
+        },
+        "65": {
+                "code": "SG",
+                "name": "Singapore"
+        },
+        "66": {
+                "code": "TH",
+                "name": "Thailand"
+        },
+        "389": {
+                "code": "MK",
+                "name": "Macedonia, The Former Yugoslav Republic of"
+        },
+        "252": {
+                "code": "SO",
+                "name": "Somalia"
+        },
+        "253": {
+                "code": "DJ",
+                "name": "Djibouti"
+        },
+        "250": {
+                "code": "RW",
+                "name": "Rwanda"
+        },
+        "251": {
+                "code": "ET",
+                "name": "Ethiopia"
+        },
+        "256": {
+                "code": "UG",
+                "name": "Uganda"
+        },
+        "257": {
+                "code": "BI",
+                "name": "Burundi"
+        },
+        "254": {
+                "code": "KE",
+                "name": "Kenya"
+        },
+        "1 939": {
+                "code": "PR",
+                "name": "Puerto Rico"
+        },
+        "977": {
+                "code": "NP",
+                "name": "Nepal"
+        },
+        "855": {
+                "code": "KH",
+                "name": "Cambodia"
+        },
+        "975": {
+                "code": "BT",
+                "name": "Bhutan"
+        },
+        "974": {
+                "code": "QA",
+                "name": "Qatar"
+        },
+        "973": {
+                "code": "BH",
+                "name": "Bahrain"
+        },
+        "972": {
+                "code": "IL",
+                "name": "Israel"
+        },
+        "971": {
+                "code": "AE",
+                "name": "United Arab Emirates"
+        },
+        "853": {
+                "code": "MO",
+                "name": "Macao"
+        },
+        "970": {
+                "code": "PS",
+                "name": "Palestinian Territory, Occupied"
+        },
+        "508": {
+                "code": "PM",
+                "name": "Saint Pierre and Miquelon"
+        },
+        "509": {
+                "code": "HT",
+                "name": "Haiti"
+        },
+        "506": {
+                "code": "CR",
+                "name": "Costa Rica"
+        },
+        "507": {
+                "code": "PA",
+                "name": "Panama"
+        },
+        "504": {
+                "code": "HN",
+                "name": "Honduras"
+        },
+        "505": {
+                "code": "NI",
+                "name": "Nicaragua"
+        },
+        "502": {
+                "code": "GT",
+                "name": "Guatemala"
+        },
+        "503": {
+                "code": "SV",
+                "name": "El Salvador"
+        },
+        "500": {
+                "code": "FK",
+                "name": "Falkland Islands (Malvinas)"
+        },
+        "501": {
+                "code": "BZ",
+                "name": "Belize"
+        },
+        "1 758": {
+                "code": "LC",
+                "name": "Saint Lucia"
+        },
+        "370": {
+                "code": "LT",
+                "name": "Lithuania"
+        },
+        "98": {
+                "code": "IR",
+                "name": "Iran, Islamic Republic of"
+        },
+        "229": {
+                "code": "BJ",
+                "name": "Benin"
+        },
+        "228": {
+                "code": "TG",
+                "name": "Togo"
+        },
+        "91": {
+                "code": "IN",
+                "name": "India"
+        },
+        "226": {
+                "code": "BF",
+                "name": "Burkina Faso"
+        },
+        "93": {
+                "code": "AF",
+                "name": "Afghanistan"
+        },
+        "224": {
+                "code": "GN",
+                "name": "Guinea"
+        },
+        "223": {
+                "code": "ML",
+                "name": "Mali"
+        },
+        "222": {
+                "code": "MR",
+                "name": "Mauritania"
+        },
+        "221": {
+                "code": "SN",
+                "name": "Senegal"
+        },
+        "220": {
+                "code": "GM",
+                "name": "Gambia"
+        },
+        "964": {
+                "code": "IQ",
+                "name": "Iraq"
+        },
+        "965": {
+                "code": "KW",
+                "name": "Kuwait"
+        },
+        "966": {
+                "code": "SA",
+                "name": "Saudi Arabia"
+        },
+        "967": {
+                "code": "YE",
+                "name": "Yemen"
+        },
+        "960": {
+                "code": "MV",
+                "name": "Maldives"
+        },
+        "961": {
+                "code": "LB",
+                "name": "Lebanon"
+        },
+        "962": {
+                "code": "JO",
+                "name": "Jordan"
+        },
+        "691": {
+                "code": "FM",
+                "name": "Micronesia, Federated States of"
+        },
+        "968": {
+                "code": "OM",
+                "name": "Oman"
+        },
+        "880": {
+                "code": "BD",
+                "name": "Bangladesh"
+        },
+        "886": {
+                "code": "TW",
+                "name": "Taiwan, Province of China"
+        },
+        "1 876": {
+                "code": "JM",
+                "name": "Jamaica"
+        },
+        "238": {
+                "code": "CV",
+                "name": "Cape Verde"
+        },
+        "239": {
+                "code": "ST",
+                "name": "Sao Tome and Principe"
+        },
+        "234": {
+                "code": "NG",
+                "name": "Nigeria"
+        },
+        "235": {
+                "code": "TD",
+                "name": "Chad"
+        },
+        "236": {
+                "code": "CF",
+                "name": "Central African Republic"
+        },
+        "237": {
+                "code": "CM",
+                "name": "Cameroon"
+        },
+        "230": {
+                "code": "MU",
+                "name": "Mauritius"
+        },
+        "231": {
+                "code": "LR",
+                "name": "Liberia"
+        },
+        "232": {
+                "code": "SL",
+                "name": "Sierra Leone"
+        },
+        "233": {
+                "code": "GH",
+                "name": "Ghana"
+        },
+        "48": {
+                "code": "PL",
+                "name": "Poland"
+        },
+        "49": {
+                "code": "DE",
+                "name": "Germany"
+        },
+        "46": {
+                "code": "SE",
+                "name": "Sweden"
+        },
+        "47": {
+                "code": "SJ",
+                "name": "Svalbard and Jan Mayen"
+        },
+        "44": {
+                "code": "JE",
+                "name": "Jersey"
+        },
+        "45": {
+                "code": "DK",
+                "name": "Denmark"
+        },
+        "872": {
+                "code": "PN",
+                "name": "Pitcairn"
+        },
+        "1 441": {
+                "code": "BM",
+                "name": "Bermuda"
+        },
+        "1 684": {
+                "code": "AS",
+                "name": "AmericanSamoa"
+        },
+        "41": {
+                "code": "CH",
+                "name": "Switzerland"
+        },
+        "1": {
+                "code": "US",
+                "name": "United States"
+        },
+        "597": {
+                "code": "SR",
+                "name": "Suriname"
+        },
+        "353": {
+                "code": "IE",
+                "name": "Ireland"
+        },
+        "688": {
+                "code": "TV",
+                "name": "Tuvalu"
+        },
+        "1 868": {
+                "code": "TT",
+                "name": "Trinidad and Tobago"
+        },
+        "1 869": {
+                "code": "KN",
+                "name": "Saint Kitts and Nevis"
+        },
+        "64": {
+                "code": "NZ",
+                "name": "New Zealand"
+        },
+        "255": {
+                "code": "TZ",
+                "name": "Tanzania, United Republic of"
+        },
+        " 345": {
+                "code": "KY",
+                "name": "Cayman Islands"
+        },
+        "683": {
+                "code": "NU",
+                "name": "Niue"
+        },
+        "686": {
+                "code": "KI",
+                "name": "Kiribati"
+        },
+        "1 340": {
+                "code": "VI",
+                "name": "Virgin Islands, U.S."
+        },
+        "356": {
+                "code": "MT",
+                "name": "Malta"
+        },
+        "355": {
+                "code": "AL",
+                "name": "Albania"
+        },
+        "354": {
+                "code": "IS",
+                "name": "Iceland"
+        },
+        "689": {
+                "code": "PF",
+                "name": "French Polynesia"
+        },
+        "352": {
+                "code": "LU",
+                "name": "Luxembourg"
+        },
+        "351": {
+                "code": "PT",
+                "name": "Portugal"
+        },
+        "350": {
+                "code": "GI",
+                "name": "Gibraltar"
+        },
+        "685": {
+                "code": "WS",
+                "name": "Samoa"
+        },
+        "687": {
+                "code": "NC",
+                "name": "New Caledonia"
+        },
+        "682": {
+                "code": "CK",
+                "name": "Cook Islands"
+        },
+        "681": {
+                "code": "WF",
+                "name": "Wallis and Futuna"
+        },
+        "680": {
+                "code": "PW",
+                "name": "Palau"
+        },
+        "359": {
+                "code": "BG",
+                "name": "Bulgaria"
+        },
+        "358": {
+                "code": "FI",
+                "name": "Finland"
+        }
+}

--- a/python/phonenumbers/phonenumberutil.py
+++ b/python/phonenumbers/phonenumberutil.py
@@ -32,6 +32,7 @@ from .re_util import fullmatch   # Extra regexp function; see README
 from .util import UnicodeMixin, u, unicod, prnt, to_long
 from .util import U_EMPTY_STRING, U_SPACE, U_DASH, U_TILDE, U_ZERO, U_SEMICOLON
 from .unicode_util import digit as unicode_digit
+from json import load
 
 # Data class definitions
 from .phonenumber import PhoneNumber, CountryCodeSource
@@ -57,6 +58,11 @@ except ImportError:  # pragma no cover
 # extra level of indirection allows the unit test to replace
 # the map with test data.
 COUNTRY_CODE_TO_REGION_CODE = _COUNTRY_CODE_TO_REGION_CODE
+
+SOURCE_FILE = 'python/phonenumbers/DialerCodes.json'
+
+with open(SOURCE_FILE) as f:
+    CC_dict = load(f)
 
 # Naming convention for phone number arguments and variables:
 #  - string arguments are named 'number'
@@ -2854,6 +2860,10 @@ def parse(number, region=None, keep_raw_input=False,
         if region is not None:
             country_code = metadata.country_code
             numobj.country_code = country_code
+            country_dict = CC_dict[str(country_code)]
+            numobj.country_id = country_dict['code']
+            numobj.country_name = country_dict['name']
+
         elif keep_raw_input:
             numobj.country_code_source = CountryCodeSource.UNSPECIFIED
 


### PR DESCRIPTION
Since geocoding takes a lot of space and time, it isn't easy to obtain the country name corresponding to a `country_code`. 
Hence I'm using a json file (22kB) to get the country name from country code.

PS. I'm participating in GSoC under Debian to develop a *Click-to-Dial popup application* [here](https://salsa.debian.org/comfortablydumb-guest/Hello-from-the-Debian-side)