### PR TITLE
Travis CI: Run flake8 to find Python syntax errors or undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ script:
         if [ "$TRAVIS_PYTHON_VERSION" = "3.6" ]; then
            pip install flake8
            # stop the build if there are Python syntax errors or undefined names
-           flake8 python --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+           flake8 python --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude=./python/phonenumbers/geodata
            # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-           flake8 python --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+           flake8 python --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=./python/phonenumbers/geodata
         fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,14 @@ script:
            coverage combine main.cov pb2.cov
            cd ..
         fi
+  - |
+        if [ "$TRAVIS_PYTHON_VERSION" = "3.6" ]; then
+           pip install flake8
+           # stop the build if there are Python syntax errors or undefined names
+           flake8 python --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+           # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+           flake8 python --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        fi
+
 after_success:
   - cd python && coveralls && cd ..


### PR DESCRIPTION
Run flake8 tests on Python 3.6 only.
