### PR TITLE
Resolve undefined names: prnt and sys

### DIFF
--- a/python/tests/phonenumbermatchertest.py
+++ b/python/tests/phonenumbermatchertest.py
@@ -23,7 +23,7 @@ import unittest
 from phonenumbers import PhoneNumberMatch, PhoneNumberMatcher, Leniency
 from phonenumbers import PhoneNumber, NumberFormat, phonenumberutil
 from phonenumbers import phonenumbermatcher, CountryCodeSource
-from phonenumbers.util import u
+from phonenumbers.util import prnt, u
 from .testmetadatatest import TestMetadataTestCase
 
 

--- a/python/tests/shortnumberinfotest.py
+++ b/python/tests/shortnumberinfotest.py
@@ -17,6 +17,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import phonenumbers
 from phonenumbers import connects_to_emergency_number, is_emergency_number, ShortNumberCost
 from phonenumbers import is_possible_short_number_for_region, is_possible_short_number


### PR DESCRIPTION
flake8 testing of https://github.com/daviddrysdale/python-phonenumbers on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude=python/phonenumbers__
```
./python/tests/phonenumbermatchertest.py:628:17: F821 undefined name 'prnt'
                prnt("No match found in  %s for leniency: %s" % (test, leniency), file=sys.stderr)
                ^
./python/tests/phonenumbermatchertest.py:632:21: F821 undefined name 'prnt'
                    prnt("Found wrong match in test %s. Found %s" % (test, match), file=sys.stderr)
                    ^
./python/tests/phonenumbermatchertest.py:643:17: F821 undefined name 'prnt'
                prnt("Match found in %s for leniency: %s" % (test, leniency), file=sys.stderr)
                ^
./python/tests/shortnumberinfotest.py:34:13: F821 undefined name 'sys'
        e = sys.exc_info()[1]
            ^
./python/tests/shortnumberinfotest.py:35:9: F821 undefined name 'self'
        self.fail("Test input data should always parse correctly: %s (%s) => %s %s" % (number, regionCode, e))
        ^
5     F821 undefined name 'prnt'
5
```

Please report changes to metadata to the upstream [libphonenumber](https://github.com/googlei18n/libphonenumber/)
project rather than here.

In other words, please do not send pull requests with changes in files under any of the
following directories:

 - `python/phonenumbers/data/`
 - `python/phonenumbers/carrierdata/`
 - `python/phonenumbers/shortdata/`
 - `python/phonenumbers/geodata/`
 - `python/phonenumbers/tzdata/`

All of these directories hold code that is autogenerated from the metadata in the `resources/`
directory, which is an exact copy of the
[equivalent directory](https://github.com/googlei18n/libphonenumber/tree/master/resources)
in the upstream project.
