### PR TITLE
Making the phonenumbermatch's __repr__ and __str__ mirror re's match …

### DIFF
--- a/python/phonenumbers/__init__.py
+++ b/python/phonenumbers/__init__.py
@@ -47,8 +47,8 @@ True
 >>> for match in phonenumbers.PhoneNumberMatcher(text, "US"):
 ...     prnt(match)
 ...
-PhoneNumberMatch [11,23) 510-748-8230
-PhoneNumberMatch [51,62) 703-4800500
+<phonenumber.PhoneNumberMatch; span=(11,23), raw_string=510-748-8230>
+<phonenumber.PhoneNumberMatch; span=(51,62), raw_string=703-4800500>
 >>> for match in phonenumbers.PhoneNumberMatcher(text, "US"):
 ...     prnt(phonenumbers.format_number(match.number, phonenumbers.PhoneNumberFormat.E164))
 ...

--- a/python/phonenumbers/phonenumbermatcher.py
+++ b/python/phonenumbers/phonenumbermatcher.py
@@ -785,4 +785,7 @@ class PhoneNumberMatch(UnicodeMixin):
                  self.number))
 
     def __unicode__(self):
-        return unicod("PhoneNumberMatch [%s,%s) %s") % (self.start, self.end, self.raw_string)
+        return unicod("<phonenumber.PhoneNumberMatch; span=({},{}), raw_string={}>".format(
+            self.start, 
+            self.end, 
+            self.raw_string))

--- a/python/phonenumbers/phonenumbermatcher.py
+++ b/python/phonenumbers/phonenumbermatcher.py
@@ -785,7 +785,7 @@ class PhoneNumberMatch(UnicodeMixin):
                  self.number))
 
     def __unicode__(self):
-        return unicod("<phonenumber.PhoneNumberMatch; span=({},{}), raw_string={}>".format(
+        return unicod("<phonenumber.PhoneNumberMatch; span=(%s,%s), raw_string=%s>")%(
             self.start, 
             self.end, 
-            self.raw_string))
+            self.raw_string)

--- a/python/tests/phonenumbermatchertest.py
+++ b/python/tests/phonenumbermatchertest.py
@@ -92,7 +92,7 @@ class PhoneNumberMatchTest(unittest.TestCase):
         number = PhoneNumber()
         match = PhoneNumberMatch(10, "1 800 234 45 67", number)
 
-        self.assertEqual("PhoneNumberMatch [10,25) 1 800 234 45 67", str(match))
+        self.assertEqual("<phonenumber.PhoneNumberMatch; span=(10,25), raw_string=1 800 234 45 67>", str(match))
         # Python version extra test
         self.assertEqual("PhoneNumberMatch(start=10, raw_string='1 800 234 45 67', "
                          "numobj=PhoneNumber(country_code=None, national_number=None, extension=None, "


### PR DESCRIPTION
…object

Modifying the __repr__ method to look similar to RE's object when you call split.  Useful for being able to refer to what the attributes of the object are.  Ran into this issue earlier.
