### PR TITLE
Wataniya changed to Ooredoo

### DIFF
--- a/resources/carrier/ar/965.txt
+++ b/resources/carrier/ar/965.txt
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 9655|فيفا
-9656|الوطنية
+9656|أوريدو
 9659|زين


### PR DESCRIPTION
updating the forgotten arabic rename of Wataniya to Ooredoo

more info at https://en.wikipedia.org/wiki/Ooredoo and http://news.kuwaittimes.net/wataniya-becomes-ooredoo-global-brand-telecom-player-now-operates-15-countries-serves-97000000-customers/

I also did the same at googlei18n/libphonenumber - https://github.com/googlei18n/libphonenumber/pull/2296

after reading the below message if its the same files but folders changed you can ignore the PR 

Please report changes to metadata to the upstream [libphonenumber](https://github.com/googlei18n/libphonenumber/)
project rather than here.

In other words, please do not send pull requests with changes in files under any of the
following directories:

 - `python/phonenumbers/data/`
 - `python/phonenumbers/carrierdata/`
 - `python/phonenumbers/shortdata/`
 - `python/phonenumbers/geodata/`
 - `python/phonenumbers/tzdata/`

All of these directories hold code that is autogenerated from the metadata in the `resources/`
directory, which is an exact copy of the
[equivalent directory](https://github.com/googlei18n/libphonenumber/tree/master/resources)
in the upstream project.

