### PR TITLE
Use class name for repr() instead of hard-coded string

### DIFF
--- a/python/phonenumbers/phonenumber.py
+++ b/python/phonenumbers/phonenumber.py
@@ -211,10 +211,11 @@ class PhoneNumber(UnicodeMixin):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return (unicod("PhoneNumber(country_code=%s, national_number=%s, extension=%s, " +
+        return (unicod("%s(country_code=%s, national_number=%s, extension=%s, " +
                        "italian_leading_zero=%s, number_of_leading_zeros=%s, " +
                        "country_code_source=%s, preferred_domestic_carrier_code=%s)") %
-                (self.country_code,
+                (type(self).__name__,
+                 self.country_code,
                  self.national_number,
                  rpr(self.extension),
                  self.italian_leading_zero,
@@ -258,3 +259,4 @@ class FrozenPhoneNumber(PhoneNumber, ImmutableMixin):
             super(FrozenPhoneNumber, self).__init__(**args[0].__dict__)
         else:
             super(FrozenPhoneNumber, self).__init__(*args, **kwargs)
+

--- a/python/tests/phonenumberutiltest.py
+++ b/python/tests/phonenumberutiltest.py
@@ -2956,6 +2956,7 @@ class PhoneNumberUtilTest(TestMetadataTestCase):
             self.fail("Expected exception on __delattr__")
         except TypeError:
             pass
+        self.assertEqual(repr(frozen1), "FrozenPhoneNumber(country_code=39, national_number=236618300, extension=None, italian_leading_zero=True, number_of_leading_zeros=None, country_code_source=0, preferred_domestic_carrier_code=None)")
 
     def testMetadataImmutable(self):
         desc = PhoneNumberDesc(national_number_pattern="\\d{4,8}")


### PR DESCRIPTION
This makes it easier to distinguish the repr of inherited classes (e.g.
FrozenPhoneNumber)