### PR TITLE
FIX error when number '0631464833' and region None

### DIFF
--- a/python/phonenumbers/phonenumberutil.py
+++ b/python/phonenumbers/phonenumberutil.py
@@ -2854,7 +2854,7 @@ def parse(number, region=None, keep_raw_input=False,
         # instead. The national number is just the normalized version of the
         # number we were given to parse.
         normalized_national_number += _normalize(national_number)
-        if region is not None:
+        if region is not None and metadata is not None:
             country_code = metadata.country_code
             numobj.country_code = country_code
         elif keep_raw_input:


### PR DESCRIPTION
FIX error "AttributeError: 'NoneType' object has no attribute 'country_code'"
look at the line 2820:
```
if region is None:
    metadata = None
```
in line 2854 
`country_code = metadata.country_code`
error when metadata is None 
and phone number without country prefix like '0631464833'

