### PR TITLE
Fix invalid escape sequences

### DIFF
--- a/tools/python/allcheck.py
+++ b/tools/python/allcheck.py
@@ -17,7 +17,7 @@ INTERNAL_FILES = ['../../python/phonenumbers/util.py',
                   '../../python/phonenumbers/re_util.py',
                   '../../python/phonenumbers/unicode_util.py']
 CLASS_RE = re.compile(r"^class +([A-Za-z][_A-Za-z0-9]+)[ \(:]")
-FUNCTION_RE = re.compile("^def +([A-Za-z][_A-Za-z0-9]+)[ \(]")
+FUNCTION_RE = re.compile(r"^def +([A-Za-z][_A-Za-z0-9]+)[ \(]")
 CONSTANT_RE = re.compile("^([A-Z][_A-Z0-9]+) *= *")
 
 grepped_all = set()

--- a/tools/python/buildmetadatafromxml.py
+++ b/tools/python/buildmetadatafromxml.py
@@ -162,7 +162,7 @@ def _dews_re(re_str):
         return re.sub(r'\s', '', re_str)
 
 
-_NUM_RE = re.compile('\d+')
+_NUM_RE = re.compile(r'\d+')
 _RANGE_RE = re.compile(r'\[(?P<min>\d+)-(?P<max>\d+)\]')
 
 
@@ -196,8 +196,8 @@ def _expand_formatting_rule(rule, national_prefix):
         return None
     if national_prefix is None:
         national_prefix = u("")
-    rule = re.sub(u("\$NP"), national_prefix, rule)
-    rule = re.sub(u("\$FG"), u("$1"), rule)
+    rule = re.sub(u(r"\$NP"), national_prefix, rule)
+    rule = re.sub(u(r"\$FG"), u("$1"), rule)
     return rule
 
 
@@ -215,7 +215,7 @@ class XAlternateNumberFormat(UnicodeMixin):
                 raise Exception("No format pattern found")
             else:
                 # Replace '$1' etc  with '\1' to match Python regexp group reference format
-                self.o.format = re.sub('\$', u(r'\\'), self.o.format)
+                self.o.format = re.sub(r'\$', u(r'\\'), self.o.format)
             xleading_digits = xtag.findall("leadingDigits")
             for xleading_digit in xleading_digits:
                 self.o.leading_digits_pattern.append(_dews_re(xleading_digit.text))
@@ -254,7 +254,7 @@ class XNumberFormat(UnicodeMixin):
                 self.o.national_prefix_formatting_rule = national_prefix_formatting_rule
             if self.o.national_prefix_formatting_rule is not None:
                 # Replace '$1' etc  with '\1' to match Python regexp group reference format
-                self.o.national_prefix_formatting_rule = re.sub('\$', r'\\', self.o.national_prefix_formatting_rule)
+                self.o.national_prefix_formatting_rule = re.sub(r'\$', r'\\', self.o.national_prefix_formatting_rule)
 
             if not self.o.national_prefix_optional_when_formatting and national_prefix_optional_when_formatting:
                 # If attrib is None, it was missing and inherits territory-wide value
@@ -269,14 +269,14 @@ class XNumberFormat(UnicodeMixin):
                 self.o.domestic_carrier_code_formatting_rule = carrier_code_formatting_rule
             if self.o.domestic_carrier_code_formatting_rule is not None:
                 # Replace '$1' etc  with '\1' to match Python regexp group reference format
-                self.o.domestic_carrier_code_formatting_rule = re.sub('\$(\d)', r'\\\1', self.o.domestic_carrier_code_formatting_rule)
+                self.o.domestic_carrier_code_formatting_rule = re.sub(r'\$(\d)', r'\\\1', self.o.domestic_carrier_code_formatting_rule)
 
             self.o.format = _get_unique_child_value(xtag, 'format')
             if self.o.format is None:
                 raise Exception("No format pattern found")
             else:
                 # Replace '$1' etc  with '\1' to match Python regexp group reference format
-                self.o.format = re.sub('\$', u(r'\\'), self.o.format)
+                self.o.format = re.sub(r'\$', u(r'\\'), self.o.format)
             xleading_digits = xtag.findall("leadingDigits")
             for xleading_digit in xleading_digits:
                 self.o.leading_digits_pattern.append(_dews_re(xleading_digit.text))
@@ -296,7 +296,7 @@ class XNumberFormat(UnicodeMixin):
                 self.io.format = self.o.format
             else:
                 # Replace '$1' etc  with '\1' to match Python regexp group reference format
-                intl_format = re.sub('\$', u(r'\\'), intl_format)
+                intl_format = re.sub(r'\$', u(r'\\'), intl_format)
                 if intl_format != DATA_NA:
                     self.io.format = intl_format
                 owning_xterr.has_explicit_intl_format = True
@@ -410,7 +410,7 @@ class XTerritory(UnicodeMixin):
         self.o.national_prefix_transform_rule = xterritory.get('nationalPrefixTransformRule', None)
         if self.o.national_prefix_transform_rule is not None:
             # Replace '$1' etc  with '\1' to match Python regexp group reference format
-            self.o.national_prefix_transform_rule = re.sub('\$', r'\\', self.o.national_prefix_transform_rule)
+            self.o.national_prefix_transform_rule = re.sub(r'\$', r'\\', self.o.national_prefix_transform_rule)
         self.o.preferred_extn_prefix = xterritory.get('preferredExtnPrefix', None)
         national_prefix_formatting_rule = xterritory.get('nationalPrefixFormattingRule', None)
         national_prefix_optional_when_formatting = get_true_attrib(xterritory, 'nationalPrefixOptionalWhenFormatting')


### PR DESCRIPTION
Starting with Python 3.6, invalid escape sequences produce a warning of
the form:

    DeprecationWarning: invalid escape sequence \d

https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior

> A backslash-character pair that is not a valid escape sequence now
> generates a DeprecationWarning. Although this will eventually become a
> SyntaxError, that will not be for several Python
> releases.
