### PR TITLE
Remove unusable shebangs

### DIFF
--- a/python/phonenumbers/util.py
+++ b/python/phonenumbers/util.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Python 2.x/3.x compatibility utilities.
 
 This module defines a collection of functions that allow the same Python

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import unittest
 
 from .phonenumbertest import PhoneNumberTest

--- a/python/tests/asyoutypetest.py
+++ b/python/tests/asyoutypetest.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Unit tests for asyoutypeformatter.py"""
 
 # Based on original Java code:

--- a/python/tests/carriertest.py
+++ b/python/tests/carriertest.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Unit tests for carrier.py"""
 
 # Based on original Java code:

--- a/python/tests/examplenumberstest.py
+++ b/python/tests/examplenumberstest.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Unit tests for phonenumberutil.py"""
 
 # Based on original Java code:

--- a/python/tests/geocodertest.py
+++ b/python/tests/geocodertest.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Unit tests for geocoder.py"""
 
 # Based on original Java code:

--- a/python/tests/pb2/__init__.py
+++ b/python/tests/pb2/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import unittest
 
 from .converttest import PB2ConvertTest

--- a/python/tests/pb2/converttest.py
+++ b/python/tests/pb2/converttest.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Unit tests for phonenumbers.pb2"""
 import unittest
 

--- a/python/tests/phonenumbermatchertest.py
+++ b/python/tests/phonenumbermatchertest.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Unit tests for phonenumbermatcher.py"""
 
 # Based on original Java code:

--- a/python/tests/shortnumberinfotest.py
+++ b/python/tests/shortnumberinfotest.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Unit tests for shortnumberinfo.py"""
 
 # Based on original Java code:

--- a/python/tests/timezonetest.py
+++ b/python/tests/timezonetest.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Unit tests for timezone.py"""
 
 # Based on original Java code:


### PR DESCRIPTION
The modified files are not marked as executable, therefore the shebang
serves no purpose. One can style execute these files individually with:

    $ python python/phonenumbers/util.py