### PR TITLE
Remove unnecessary indirection through U_* constants

### DIFF
--- a/python/phonenumbers/asyoutypeformatter.py
+++ b/python/phonenumbers/asyoutypeformatter.py
@@ -26,7 +26,7 @@ See the unit tests for more details on how the formatter is to be used.
 # limitations under the License.
 import re
 
-from .util import u, unicod, U_EMPTY_STRING, U_SPACE
+from .util import u, unicod
 from .unicode_util import digit as unicode_digit
 from .re_util import fullmatch
 from .phonemetadata import PhoneMetadata
@@ -38,7 +38,7 @@ from .phonenumberutil import _formatting_rule_has_first_group_only
 
 # Character used when appropriate to separate a prefix, such as a long NDD or
 # a country calling code, from the national number.
-_SEPARATOR_BEFORE_NATIONAL_NUMBER = U_SPACE
+_SEPARATOR_BEFORE_NATIONAL_NUMBER = " "
 _EMPTY_METADATA = PhoneMetadata(id=unicod(""),
                                 international_prefix=unicod("NA"),
                                 register=False)
@@ -175,7 +175,7 @@ class AsYouTypeFormatter(object):
 
     def _create_formatting_template(self, num_format):
         number_pattern = num_format.pattern
-        self.formatting_template = U_EMPTY_STRING
+        self.formatting_template = ""
         temp_template = self._get_formatting_template(number_pattern, num_format.format)
         if len(temp_template) > 0:
             self._formatting_template = temp_template
@@ -195,7 +195,7 @@ class AsYouTypeFormatter(object):
         # entered so far is longer than the maximum the current formatting
         # rule can accommodate.
         if len(a_phone_number) < len(self._national_number):
-            return U_EMPTY_STRING
+            return ""
         # Formats the number according to number_format
         template = re.sub(number_pattern, number_format, a_phone_number)
         # Replaces each digit with character _DIGIT_PLACEHOLDER
@@ -204,25 +204,25 @@ class AsYouTypeFormatter(object):
 
     def _clear(self):
         """Clears the internal state of the formatter, so it can be reused."""
-        self._current_output = U_EMPTY_STRING
-        self._accrued_input = U_EMPTY_STRING
-        self._accrued_input_without_formatting = U_EMPTY_STRING
-        self._formatting_template = U_EMPTY_STRING
+        self._current_output = ""
+        self._accrued_input = ""
+        self._accrued_input_without_formatting = ""
+        self._formatting_template = ""
         self._last_match_position = 0
 
         # The pattern from number_format that is currently used to create
         # formatting_template.
-        self._current_formatting_pattern = U_EMPTY_STRING
+        self._current_formatting_pattern = ""
         # This contains anything that has been entered so far preceding the
         # national significant number, and it is formatted (e.g. with space
         # inserted). For example, this can contain IDD, country code, and/or
         # NDD, etc.
-        self._prefix_before_national_number = U_EMPTY_STRING
+        self._prefix_before_national_number = ""
         self._should_add_space_after_national_prefix = False
         # This contains the national prefix that has been extracted. It
         # contains only digits without formatting.
-        self._extracted_national_prefix = U_EMPTY_STRING
-        self._national_number = U_EMPTY_STRING
+        self._extracted_national_prefix = ""
+        self._national_number = ""
         # This indicates whether AsYouTypeFormatter is currently doing the
         # formatting.
         self._able_to_format = True
@@ -357,8 +357,8 @@ class AsYouTypeFormatter(object):
         self._is_expecting_country_calling_code = False
         self._possible_formats = []
         self._last_match_position = 0
-        self._formatting_template = U_EMPTY_STRING
-        self._current_formatting_pattern = U_EMPTY_STRING
+        self._formatting_template = ""
+        self._current_formatting_pattern = ""
         return self._attempt_to_choose_formatting_pattern()
 
     # Some national prefixes are a substring of others. If extracting the
@@ -395,7 +395,7 @@ class AsYouTypeFormatter(object):
                     self._should_add_space_after_national_prefix = bool(_NATIONAL_PREFIX_SEPARATORS_PATTERN.search(number_format.national_prefix_formatting_rule))
                 formatted_number = re.sub(num_re, number_format.format, self._national_number)
                 return self._append_national_number(formatted_number)
-        return U_EMPTY_STRING
+        return ""
 
     def get_remembered_position(self):
         """Returns the current position in the partially formatted phone
@@ -453,7 +453,7 @@ class AsYouTypeFormatter(object):
         accrued, and returns a formatted string in the end."""
         length_of_national_number = len(self._national_number)
         if length_of_national_number > 0:
-            temp_national_number = U_EMPTY_STRING
+            temp_national_number = ""
             for ii in range(length_of_national_number):
                 temp_national_number = self._input_digit_helper(self._national_number[ii])
             if self._able_to_format:
@@ -507,7 +507,7 @@ class AsYouTypeFormatter(object):
         default_country.
         """
         international_prefix = re.compile(unicod("\\") + _PLUS_SIGN + unicod("|") +
-                                          (self._current_metadata.international_prefix or U_EMPTY_STRING))
+                                          (self._current_metadata.international_prefix or ""))
         idd_match = international_prefix.match(self._accrued_input_without_formatting)
         if idd_match:
             self._is_complete_number = True
@@ -544,7 +544,7 @@ class AsYouTypeFormatter(object):
         self._prefix_before_national_number += _SEPARATOR_BEFORE_NATIONAL_NUMBER
         # When we have successfully extracted the IDD, the previously
         # extracted NDD should be cleared because it is no longer valid.
-        self._extracted_national_prefix = U_EMPTY_STRING
+        self._extracted_national_prefix = ""
         return True
 
     def _normalize_and_accrue_digits_and_plus_sign(self, next_char, remember_position):
@@ -591,5 +591,5 @@ class AsYouTypeFormatter(object):
                 # no other valid patterns to try.
                 self._able_to_format = False
             # else, we just reset the formatting pattern.
-            self._current_formatting_pattern = U_EMPTY_STRING
+            self._current_formatting_pattern = ""
             return self._accrued_input

--- a/python/phonenumbers/carrier.py
+++ b/python/phonenumbers/carrier.py
@@ -25,7 +25,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .util import prnt, u, U_EMPTY_STRING
+from .util import prnt, u
 from .phonenumberutil import PhoneNumberType, number_type
 from .phonenumberutil import region_code_for_number
 from .phonenumberutil import is_mobile_number_portable_region
@@ -105,7 +105,7 @@ def name_for_number(numobj, lang, script=None, region=None):
     ntype = number_type(numobj)
     if _is_mobile(ntype):
         return name_for_valid_number(numobj, lang, script, region)
-    return U_EMPTY_STRING
+    return ""
 
 
 def safe_display_name(numobj, lang, script=None, region=None):
@@ -129,7 +129,7 @@ def safe_display_name(numobj, lang, script=None, region=None):
     Returns a carrier name that is safe to display to users, or the empty string.
     """
     if is_mobile_number_portable_region(region_code_for_number(numobj)):
-        return U_EMPTY_STRING
+        return ""
     return name_for_number(numobj, lang, script, region)
 
 

--- a/python/phonenumbers/geocoder.py
+++ b/python/phonenumbers/geocoder.py
@@ -44,7 +44,7 @@ True
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .util import prnt, unicod, u, U_EMPTY_STRING
+from .util import prnt, unicod, u
 from .phonenumberutil import region_code_for_number, PhoneNumberType
 from .phonenumberutil import country_mobile_token, national_significant_number, number_type
 from .phonenumberutil import region_code_for_country_code, region_codes_for_country_code
@@ -101,7 +101,7 @@ def country_name_for_number(numobj, lang, script=None, region=None):
                 # then we don't know which region it belongs to so we return
                 # nothing.
                 if region_where_number_is_valid != u("ZZ"):
-                    return U_EMPTY_STRING
+                    return ""
                 region_where_number_is_valid = region_code
         return _region_display_name(region_where_number_is_valid, lang, script, region)
 
@@ -116,7 +116,7 @@ def _region_display_name(region_code, lang, script=None, region=None):
             other_lang = name[1:]
             name = LOCALE_DATA[region_code].get(other_lang, "")
         return unicod(name)
-    return U_EMPTY_STRING
+    return ""
 
 
 def description_for_valid_number(numobj, lang, script=None, region=None):
@@ -162,7 +162,7 @@ def description_for_valid_number(numobj, lang, script=None, region=None):
     if region is None or region == number_region:
         mobile_token = country_mobile_token(numobj.country_code)
         national_number = national_significant_number(numobj)
-        if mobile_token != U_EMPTY_STRING and national_number.startswith(mobile_token):
+        if mobile_token != "" and national_number.startswith(mobile_token):
             # In some countries, eg. Argentina, mobile numbers have a mobile token
             # before the national destination code, this should be removed before
             # geocoding.

--- a/python/phonenumbers/phonenumbermatcher.py
+++ b/python/phonenumbers/phonenumbermatcher.py
@@ -21,7 +21,6 @@ import re
 # Extra regexp function; see README
 from .re_util import fullmatch
 from .util import UnicodeMixin, u, unicod, prnt
-from .util import U_EMPTY_STRING, U_DASH, U_SEMICOLON, U_SLASH, U_X_LOWER, U_X_UPPER, U_PERCENT
 from .unicode_util import Category, Block, is_letter
 from .phonenumberutil import _MAX_LENGTH_FOR_NSN, _MAX_LENGTH_COUNTRY_CODE
 from .phonenumberutil import _VALID_PUNCTUATION, _PLUS_CHARS, NON_DIGITS_PATTERN
@@ -281,7 +280,7 @@ def _all_number_groups_remain_grouped(numobj, normalized_candidate, formatted_nu
     # The check here makes sure that we haven't mistakenly already used the extension to
     # match the last group of the subscriber number. Note the extension cannot have
     # formatting in-between digits.
-    return (normalized_candidate[from_index:].find(numobj.extension or U_EMPTY_STRING) != -1)
+    return (normalized_candidate[from_index:].find(numobj.extension or "") != -1)
 
 
 def _verify_exact_grouping(numobj, candidate, matcher):
@@ -343,13 +342,13 @@ def _get_national_number_groups_without_pattern(numobj):
     rfc3966_format = format_number(numobj, PhoneNumberFormat.RFC3966)
     # We remove the extension part from the formatted string before splitting
     # it into different groups.
-    end_index = rfc3966_format.find(U_SEMICOLON)
+    end_index = rfc3966_format.find(";")
     if end_index < 0:
         end_index = len(rfc3966_format)
 
     # The country-code will have a '-' following it.
-    start_index = rfc3966_format.find(U_DASH) + 1
-    return rfc3966_format[start_index:end_index].split(U_DASH)
+    start_index = rfc3966_format.find("-") + 1
+    return rfc3966_format[start_index:end_index].split("-")
 
 
 def _get_national_number_groups(numobj, formatting_pattern):
@@ -359,16 +358,16 @@ def _get_national_number_groups(numobj, formatting_pattern):
     # If a format is provided, we format the NSN only, and split that according to the separator.
     nsn = national_significant_number(numobj)
     return _format_nsn_using_pattern(nsn, formatting_pattern,
-                                     PhoneNumberFormat.RFC3966).split(U_DASH)
+                                     PhoneNumberFormat.RFC3966).split("-")
 
 
 def _contains_more_than_one_slash_in_national_number(numobj, candidate):
-    first_slash_in_body_index = candidate.find(U_SLASH)
+    first_slash_in_body_index = candidate.find("/")
     if first_slash_in_body_index < 0:
         # No slashes, this is okay.
         return False
     # Now look for a second one.
-    second_slash_in_body_index = candidate.find(U_SLASH, first_slash_in_body_index + 1)
+    second_slash_in_body_index = candidate.find("/", first_slash_in_body_index + 1)
     if second_slash_in_body_index < 0:
         # Only one slash, this is okay.,
         return False
@@ -380,7 +379,7 @@ def _contains_more_than_one_slash_in_national_number(numobj, candidate):
         normalize_digits_only(candidate[:first_slash_in_body_index]) ==
         unicod(numobj.country_code)):
         # Any more slashes and this is illegal.
-        return (candidate[(second_slash_in_body_index + 1):].find(U_SLASH) != -1)
+        return (candidate[(second_slash_in_body_index + 1):].find("/") != -1)
     return True
 
 
@@ -394,9 +393,9 @@ def _contains_only_valid_x_chars(numobj, candidate):
     # character of the string.
     ii = 0
     while ii < (len(candidate) - 1):
-        if (candidate[ii] == U_X_LOWER or candidate[ii] == U_X_UPPER):
+        if (candidate[ii] == "x" or candidate[ii] == "X"):
             next_char = candidate[ii + 1]
-            if (next_char == U_X_LOWER or next_char == U_X_UPPER):
+            if (next_char == "x" or next_char == "X"):
                 # This is the carrier code case, in which the 'X's always
                 # precede the national significant number.
                 ii += 1
@@ -479,7 +478,7 @@ class PhoneNumberMatcher(object):
         # The text searched for phone numbers.
         self.text = text
         if self.text is None:
-            self.text = U_EMPTY_STRING
+            self.text = ""
         # The region (country) to assume for phone numbers without an
         # international prefix, possibly None.
         self.preferred_region = region
@@ -550,7 +549,7 @@ class PhoneNumberMatcher(object):
 
     @classmethod
     def _is_invalid_punctuation_symbol(cls, character):
-        return (character == U_PERCENT or
+        return (character == "%" or
                 Category.get(character) == Category.CURRENCY_SYMBOL)
 
     def _extract_match(self, candidate, offset):

--- a/python/phonenumbers/phonenumberutil.py
+++ b/python/phonenumbers/phonenumberutil.py
@@ -30,7 +30,6 @@ import re
 
 from .re_util import fullmatch   # Extra regexp function; see README
 from .util import UnicodeMixin, u, unicod, prnt, to_long
-from .util import U_EMPTY_STRING, U_SPACE, U_DASH, U_TILDE, U_ZERO, U_SEMICOLON
 from .unicode_util import digit as unicode_digit
 
 # Data class definitions
@@ -204,8 +203,8 @@ _VALID_PUNCTUATION = (u("-x\u2010-\u2015\u2212\u30FC\uFF0D-\uFF0F ") +
 _DIGITS = unicod('\\d')  # Java "\\p{Nd}", so need "(?u)" or re.UNICODE wherever this is used
 # We accept alpha characters in phone numbers, ASCII only, upper and lower
 # case.
-_VALID_ALPHA = (U_EMPTY_STRING.join(_ALPHA_MAPPINGS.keys()) +
-                U_EMPTY_STRING.join([_k.lower() for _k in _ALPHA_MAPPINGS.keys()]))
+_VALID_ALPHA = ("".join(_ALPHA_MAPPINGS.keys()) +
+                "".join([_k.lower() for _k in _ALPHA_MAPPINGS.keys()]))
 _PLUS_CHARS = u("+\uFF0B")
 _PLUS_CHARS_PATTERN = re.compile(u("[") + _PLUS_CHARS + u("]+"))
 _SEPARATOR_PATTERN = re.compile(u("[") + _VALID_PUNCTUATION + u("]+"))
@@ -539,7 +538,7 @@ def _extract_possible_number(number):
             number = number[:second_number_match.start()]
         return number
     else:
-        return U_EMPTY_STRING
+        return ""
 
 
 def _is_viable_phone_number(number):
@@ -605,7 +604,7 @@ def normalize_digits_only(number, keep_non_digits=False):
     """
     number = unicod(number)
     number_length = len(number)
-    normalized_digits = U_EMPTY_STRING
+    normalized_digits = ""
     for ii in range(number_length):
         d = unicode_digit(number[ii], -1)
         if d != -1:
@@ -764,7 +763,7 @@ def length_of_national_destination_code(numobj):
         # the mobile token is always formatted separately from the rest of the
         # phone number.
         mobile_token = country_mobile_token(numobj.country_code)
-        if mobile_token != U_EMPTY_STRING:
+        if mobile_token != "":
             return len(number_groups[2]) + len(number_groups[3])
     return len(number_groups[2])
 
@@ -778,7 +777,7 @@ def country_mobile_token(country_code):
     country_code -- the country calling code for which we want the mobile token
     Returns the mobile token, as a string, for the given country calling code.
     """
-    return _MOBILE_TOKEN_MAPPINGS.get(country_code, U_EMPTY_STRING)
+    return _MOBILE_TOKEN_MAPPINGS.get(country_code, "")
 
 
 def _normalize_helper(number, replacements, remove_non_matches):
@@ -804,7 +803,7 @@ def _normalize_helper(number, replacements, remove_non_matches):
         elif not remove_non_matches:
             normalized_number.append(char)
         # If neither of the above are true, we remove this character
-    return U_EMPTY_STRING.join(normalized_number)
+    return "".join(normalized_number)
 
 
 def supported_calling_codes():
@@ -1020,7 +1019,7 @@ def format_by_pattern(numobj, number_format, user_defined_formats):
     # Metadata cannot be None because the country calling code is valid.
     metadata = PhoneMetadata.metadata_for_region_or_calling_code(country_code, region_code)
 
-    formatted_number = U_EMPTY_STRING
+    formatted_number = ""
     formatting_pattern = _choose_formatting_pattern_for_number(user_defined_formats, nsn)
     if formatting_pattern is None:
         # If no pattern above is matched, we format the number as a whole.
@@ -1149,10 +1148,10 @@ def format_number_for_mobile_dialing(numobj, region_calling_from, with_formattin
     country_calling_code = numobj.country_code
     if not _has_valid_country_calling_code(country_calling_code):
         if numobj.raw_input is None:
-            return U_EMPTY_STRING
+            return ""
         else:
             return numobj.raw_input
-    formatted_number = U_EMPTY_STRING
+    formatted_number = ""
     # Clear the extension, as that part cannot normally be dialed together with the main number.
     numobj_no_ext = PhoneNumber()
     numobj_no_ext.merge_from(numobj)
@@ -1181,7 +1180,7 @@ def format_number_for_mobile_dialing(numobj, region_calling_from, with_formattin
                 # carrier code when called within Brazil. Without that, most of
                 # the carriers won't connect the call.  Because of that, we return
                 # an empty string here.
-                formatted_number = U_EMPTY_STRING
+                formatted_number = ""
         elif is_valid_number and region_code == "HU":
             # The national format for HU numbers doesn't contain the national
             # prefix, because that is how numbers are normally written
@@ -1189,7 +1188,7 @@ def format_number_for_mobile_dialing(numobj, region_calling_from, with_formattin
             # from a mobile phone, except for short numbers. As a result, we
             # add it back here if it is a valid regular length phone number.
             formatted_number = (ndd_prefix_for_region(region_code, True) +  # strip non-digits
-                                U_SPACE + format_number(numobj_no_ext, PhoneNumberFormat.NATIONAL))
+                                " " + format_number(numobj_no_ext, PhoneNumberFormat.NATIONAL))
         elif country_calling_code == _NANPA_COUNTRY_CODE:
             # For NANPA countries, we output international format for numbers
             # that can be dialed internationally, since that always works,
@@ -1282,7 +1281,7 @@ def format_out_of_country_calling_number(numobj, region_calling_from):
         if is_nanpa_country(region_calling_from):
             # For NANPA regions, return the national format for these regions
             # but prefix it with the country calling code.
-            return (unicod(country_code) + U_SPACE +
+            return (unicod(country_code) + " " +
                     format_number(numobj, PhoneNumberFormat.NATIONAL))
     elif country_code == country_code_for_valid_region(region_calling_from):
         # If regions share a country calling code, the country calling code
@@ -1303,7 +1302,7 @@ def format_out_of_country_calling_number(numobj, region_calling_from):
     # For regions that have multiple international prefixes, the international
     # format of the number is returned, unless there is a preferred
     # international prefix.
-    i18n_prefix_for_formatting = U_EMPTY_STRING
+    i18n_prefix_for_formatting = ""
     i18n_match = fullmatch(_SINGLE_INTERNATIONAL_PREFIX, international_prefix)
     if i18n_match:
         i18n_prefix_for_formatting = international_prefix
@@ -1321,8 +1320,8 @@ def format_out_of_country_calling_number(numobj, region_calling_from):
                                                          PhoneNumberFormat.INTERNATIONAL,
                                                          formatted_national_number)
     if len(i18n_prefix_for_formatting) > 0:
-        formatted_number = (i18n_prefix_for_formatting + U_SPACE +
-                            unicod(country_code) + U_SPACE + formatted_number)
+        formatted_number = (i18n_prefix_for_formatting + " " +
+                            unicod(country_code) + " " + formatted_number)
     else:
         formatted_number = _prefix_number_with_country_calling_code(country_code,
                                                                     PhoneNumberFormat.INTERNATIONAL,
@@ -1512,7 +1511,7 @@ def format_out_of_country_keeping_alpha_chars(numobj, region_calling_from):
     metadata_for_region_calling_from = PhoneMetadata.metadata_for_region(region_calling_from.upper(), None)
     if country_code == _NANPA_COUNTRY_CODE:
         if is_nanpa_country(region_calling_from):
-            return unicod(country_code) + U_SPACE + num_raw_input
+            return unicod(country_code) + " " + num_raw_input
     elif (metadata_for_region_calling_from is not None and
           country_code == country_code_for_region(region_calling_from)):
         formatting_pattern = _choose_formatting_pattern_for_number(metadata_for_region_calling_from.number_format,
@@ -1536,7 +1535,7 @@ def format_out_of_country_keeping_alpha_chars(numobj, region_calling_from):
         return _format_nsn_using_pattern(num_raw_input,
                                          new_format,
                                          PhoneNumberFormat.NATIONAL)
-    i18n_prefix_for_formatting = U_EMPTY_STRING
+    i18n_prefix_for_formatting = ""
     # If an unsupported region-calling-from is entered, or a country with
     # multiple international prefixes, the international format of the number
     # is returned, unless there is a preferred international prefix.
@@ -1556,8 +1555,8 @@ def format_out_of_country_keeping_alpha_chars(numobj, region_calling_from):
                                                          PhoneNumberFormat.INTERNATIONAL,
                                                          num_raw_input)
     if i18n_prefix_for_formatting:
-        formatted_number = (i18n_prefix_for_formatting + U_SPACE +
-                            unicod(country_code) + U_SPACE + formatted_number)
+        formatted_number = (i18n_prefix_for_formatting + " " +
+                            unicod(country_code) + " " + formatted_number)
     else:
         # Invalid region entered as country-calling-from (so no metadata was
         # found for it) or the region chosen has multiple international
@@ -1583,13 +1582,13 @@ def national_significant_number(numobj):
     """
     # If leading zero(s) have been set, we prefix this now. Note this is not a
     # national prefix.
-    national_number = U_EMPTY_STRING
+    national_number = ""
     if numobj.italian_leading_zero:
         num_zeros = numobj.number_of_leading_zeros
         if num_zeros is None:
             num_zeros = 1
         if num_zeros > 0:
-            national_number = U_ZERO * num_zeros
+            national_number = "0" * num_zeros
     national_number += str(numobj.national_number)
     return national_number
 
@@ -1599,9 +1598,9 @@ def _prefix_number_with_country_calling_code(country_code, num_format, formatted
     if num_format == PhoneNumberFormat.E164:
         return _PLUS_SIGN + unicod(country_code) + formatted_number
     elif num_format == PhoneNumberFormat.INTERNATIONAL:
-        return _PLUS_SIGN + unicod(country_code) + U_SPACE + formatted_number
+        return _PLUS_SIGN + unicod(country_code) + " " + formatted_number
     elif num_format == PhoneNumberFormat.RFC3966:
-        return _RFC3966_PREFIX + _PLUS_SIGN + unicod(country_code) + U_DASH + formatted_number
+        return _RFC3966_PREFIX + _PLUS_SIGN + unicod(country_code) + "-" + formatted_number
     else:
         return formatted_number
 
@@ -1651,7 +1650,7 @@ def _format_nsn_using_pattern(national_number, formatting_pattern, number_format
     # carrier code replacement will take place.
     number_format_rule = formatting_pattern.format
     m_re = re.compile(formatting_pattern.pattern)
-    formatted_national_number = U_EMPTY_STRING
+    formatted_national_number = ""
 
     if (number_format == PhoneNumberFormat.NATIONAL and carrier_code and
         formatting_pattern.domestic_carrier_code_formatting_rule):
@@ -1685,9 +1684,9 @@ def _format_nsn_using_pattern(national_number, formatting_pattern, number_format
         # Strip any leading punctuation.
         m = _SEPARATOR_PATTERN.match(formatted_national_number)
         if m:
-            formatted_national_number = re.sub(_SEPARATOR_PATTERN, U_EMPTY_STRING, formatted_national_number, count=1)
+            formatted_national_number = re.sub(_SEPARATOR_PATTERN, "", formatted_national_number, count=1)
         # Replace the rest with a dash between each number group
-        formatted_national_number = re.sub(_SEPARATOR_PATTERN, U_DASH, formatted_national_number)
+        formatted_national_number = re.sub(_SEPARATOR_PATTERN, "-", formatted_national_number)
 
     return formatted_national_number
 
@@ -2161,7 +2160,7 @@ def ndd_prefix_for_region(region_code, strip_non_digits):
     if strip_non_digits:
         # Note: if any other non-numeric symbols are ever used in national
         # prefixes, these would have to be removed here as well.
-        national_prefix = re.sub(U_TILDE, U_EMPTY_STRING, national_prefix)
+        national_prefix = re.sub("~", "", national_prefix)
     return national_prefix
 
 
@@ -2437,7 +2436,7 @@ def _extract_country_code(number):
     number) if number doesn't start with a valid country calling code.
     """
 
-    if len(number) == 0 or number[0] == U_ZERO:
+    if len(number) == 0 or number[0] == "0":
         # Country codes do not begin with a '0'.
         return (0, number)
     for ii in range(1, min(len(number), _MAX_LENGTH_COUNTRY_CODE) + 1):
@@ -2493,7 +2492,7 @@ def _maybe_extract_country_code(number, metadata, keep_raw_input, numobj):
         was extracted, this will be empty.
     """
     if len(number) == 0:
-        return (0, U_EMPTY_STRING)
+        return (0, "")
     full_number = number
     # Set the default prefix to be something that will never match.
     possible_country_idd_prefix = unicod("NonMatch")
@@ -2546,7 +2545,7 @@ def _maybe_extract_country_code(number, metadata, keep_raw_input, numobj):
 
     # No country calling code present.
     numobj.country_code = 0
-    return (0, U_EMPTY_STRING)
+    return (0, "")
 
 
 def _parse_prefix_as_idd(idd_pattern, number):
@@ -2566,7 +2565,7 @@ def _parse_prefix_as_idd(idd_pattern, number):
         digit_match = _CAPTURING_DIGIT_PATTERN.search(number[match_end:])
         if digit_match:
             normalized_group = normalize_digits_only(digit_match.group(1))
-            if normalized_group == U_ZERO:
+            if normalized_group == "0":
                 return (False, number)
         return (True, number[match_end:])
     return (False, number)
@@ -2625,13 +2624,13 @@ def _maybe_strip_national_prefix_carrier_code(number, metadata):
      - The number with the prefix stripped.
      - Boolean indicating if a national prefix or carrier code (or both) could be extracted.
      """
-    carrier_code = U_EMPTY_STRING
+    carrier_code = ""
     possible_national_prefix = metadata.national_prefix_for_parsing
     if (len(number) == 0 or
         possible_national_prefix is None or
         len(possible_national_prefix) == 0):
         # Early return for numbers of zero length.
-        return (U_EMPTY_STRING, number, False)
+        return ("", number, False)
 
     # Attempt to parse the first digits as a national prefix.
     prefix_pattern = re.compile(possible_national_prefix)
@@ -2652,7 +2651,7 @@ def _maybe_strip_national_prefix_carrier_code(number, metadata):
             # Check that the resultant number is viable. If not, return.
             national_number_match = _match_national_number(number[prefix_match.end():], general_desc, False)
             if (is_viable_original_number and not national_number_match):
-                return (U_EMPTY_STRING, number, False)
+                return ("", number, False)
 
             if (num_groups > 0 and
                 prefix_match.groups(num_groups) is not None):
@@ -2720,13 +2719,13 @@ def _check_region_for_parsing(number, default_region):
 def _set_italian_leading_zeros_for_phone_number(national_number, numobj):
     """A helper function to set the values related to leading zeros in a
     PhoneNumber."""
-    if len(national_number) > 1 and national_number[0] == U_ZERO:
+    if len(national_number) > 1 and national_number[0] == "0":
         numobj.italian_leading_zero = True
         number_of_leading_zeros = 1
         # Note that if the number is all "0"s, the last "0" is not counted as
         # a leading zero.
         while (number_of_leading_zeros < len(national_number) - 1 and
-               national_number[number_of_leading_zeros] == U_ZERO):
+               national_number[number_of_leading_zeros] == "0"):
             number_of_leading_zeros += 1
         if number_of_leading_zeros != 1:
             numobj.number_of_leading_zeros = number_of_leading_zeros
@@ -2906,13 +2905,13 @@ def _build_national_number_for_parsing(number):
             # Additional parameters might follow the phone context. If so, we
             # will remove them here because the parameters after phone context
             # are not important for parsing the phone number.
-            phone_context_end = number.find(U_SEMICOLON, phone_context_start)
+            phone_context_end = number.find(";", phone_context_start)
             if phone_context_end > 0:
                 national_number = number[phone_context_start:phone_context_end]
             else:
                 national_number = number[phone_context_start:]
         else:
-            national_number = U_EMPTY_STRING
+            national_number = ""
         # Now append everything between the "tel:" prefix and the
         # phone-context. This should include the national number, an optional
         # extension or isdn-subaddress component. Note we also handle the case

--- a/python/phonenumbers/prefix.py
+++ b/python/phonenumbers/prefix.py
@@ -1,6 +1,5 @@
 """Utilities for handling prefix dictionaries"""
 
-from .util import U_EMPTY_STRING, U_PLUS
 from .phonenumberutil import format_number, PhoneNumberFormat
 
 _LOCALE_NORMALIZATION_MAP = {"zh_TW": "zh_Hant", "zh_HK": "zh_Hant", "zh_MO": "zh_Hant"}
@@ -73,7 +72,7 @@ def _prefix_description_for_number(data, longest_prefix, numobj, lang, script=No
     Returns a text description in the given language code, for the given phone
     number's area, or an empty string if no description is available."""
     e164_num = format_number(numobj, PhoneNumberFormat.E164)
-    if not e164_num.startswith(U_PLUS):  # pragma no cover
+    if not e164_num.startswith("+"):  # pragma no cover
         # Can only hit this arm if there's an internal error in the rest of
         # the library
         raise Exception("Expect E164 number to start with +")
@@ -86,5 +85,5 @@ def _prefix_description_for_number(data, longest_prefix, numobj, lang, script=No
             if name is not None:
                 return name
             else:
-                return U_EMPTY_STRING
-    return U_EMPTY_STRING
+                return ""
+    return ""

--- a/python/phonenumbers/shortnumberinfo.py
+++ b/python/phonenumbers/shortnumberinfo.py
@@ -18,7 +18,7 @@ Note most commercial short numbers are not handled here, but by phonenumberutil.
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .util import U_EMPTY_STRING, prnt
+from .util import prnt
 from .phonemetadata import PhoneMetadata
 from .phonenumberutil import _extract_possible_number, _PLUS_CHARS_PATTERN
 from .phonenumberutil import normalize_digits_only, region_codes_for_country_code
@@ -285,11 +285,11 @@ def _example_short_number(region_code):
     """
     metadata = PhoneMetadata.short_metadata_for_region(region_code)
     if metadata is None:
-        return U_EMPTY_STRING
+        return ""
     desc = metadata.short_code
     if desc.example_number is not None:
         return desc.example_number
-    return U_EMPTY_STRING
+    return ""
 
 
 def _example_short_number_for_cost(region_code, cost):
@@ -305,7 +305,7 @@ def _example_short_number_for_cost(region_code, cost):
     """
     metadata = PhoneMetadata.short_metadata_for_region(region_code)
     if metadata is None:
-        return U_EMPTY_STRING
+        return ""
     desc = None
     if cost == ShortNumberCost.TOLL_FREE:
         desc = metadata.toll_free
@@ -319,7 +319,7 @@ def _example_short_number_for_cost(region_code, cost):
         pass
     if desc is not None and desc.example_number is not None:
         return desc.example_number
-    return U_EMPTY_STRING
+    return ""
 
 
 def connects_to_emergency_number(number, region_code):

--- a/python/phonenumbers/timezone.py
+++ b/python/phonenumbers/timezone.py
@@ -34,7 +34,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .util import prnt, u, U_PLUS
+from .util import prnt, u
 from .phonenumberutil import PhoneNumberType, number_type
 from .phonenumberutil import PhoneNumberFormat, format_number
 from .phonenumberutil import is_number_type_geographical
@@ -75,7 +75,7 @@ def time_zones_for_geographical_number(numobj):
     with the default unknown time zone if no other time zone was found or if
     the number was invalid"""
     e164_num = format_number(numobj, PhoneNumberFormat.E164)
-    if not e164_num.startswith(U_PLUS):  # pragma no cover
+    if not e164_num.startswith("+"):  # pragma no cover
         # Can only hit this arm if there's an internal error in the rest of
         # the library
         raise Exception("Expect E164 number to start with +")

--- a/python/phonenumbers/util.py
+++ b/python/phonenumbers/util.py
@@ -100,20 +100,6 @@ else:  # pragma no cover
         def __str__(self):
             return unicode(self).encode('utf-8')
 
-# Constants for Unicode strings
-U_EMPTY_STRING = unicod("")
-U_SPACE = unicod(" ")
-U_DASH = unicod("-")
-U_TILDE = unicod("~")
-U_PLUS = unicod("+")
-U_STAR = unicod("*")
-U_ZERO = unicod("0")
-U_SLASH = unicod("/")
-U_SEMICOLON = unicod(";")
-U_X_LOWER = unicod("x")
-U_X_UPPER = unicod("X")
-U_PERCENT = unicod("%")
-
 
 def rpr(s):
     """Create a representation of a Unicode string that can be used in both


### PR DESCRIPTION
Makes the code easier to read, follow, and adapt by reducing the amount
of indirection. The constants offered no additional abstraction.
