### PR TITLE
Clean up MANIFEST.in and remove unnecessary entries

### DIFF
--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,8 +1,2 @@
 recursive-include tests *.py
-include MANIFEST.in
-include MANIFEST
-include HISTORY
-include LICENSE
-include README.md
-include setup.py
-exclude .*ignore
+include HISTORY.md


### PR DESCRIPTION
- History was renamed to HISTORY.md in 97cc376610733bf5c52116bf3661ddeb14eaf0bc.
- Setuptools automatically includes setup.py, MANIFEST.in, LICENSE, and README.md. No need to specify these.