### PR TITLE
🏷️ Restore Liskov adherence in `_BlockRange` equality operators

### DIFF
--- a/python/phonenumbers/unicode_util.py
+++ b/python/phonenumbers/unicode_util.py
@@ -144,6 +144,8 @@ class _BlockRange(UnicodeMixin):
             regdict[start] = self
 
     def __eq__(self, other):
+        if not isinstance(other, _BlockRange):
+            return NotImplemented
         return (self.start == other.start and self.end == other.end)
 
     def __ne__(self, other):


### PR DESCRIPTION
As per https://github.com/daviddrysdale/python-phonenumbers/issues/200#issuecomment-910923489

A
