### PR TITLE
ci: pin protobuf=3.17.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install protobuf pycodestyle
+        pip install protobuf==3.17.3 pycodestyle
     - name: Lint
       run: make -C tools/python lint
     - name: Test

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install protobuf coveralls
+        pip install protobuf==3.17.3 pycodestyle
     - name: Test with coverage
       run: |
         cd python

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,14 +7,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 2.7
+    - name: Set up latest Python 3
       uses: actions/setup-python@v2
       with:
-        python-version: 2.7
+        python-version: 3
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install protobuf==3.17.3 pycodestyle
+        pip install protobuf pycodestyle coverage coveralls
     - name: Test with coverage
       run: |
         cd python


### PR DESCRIPTION
The 3.18.0 release of the protobuf package removed Python 2.x support.
For now, pin to the previous release.
