### PR TITLE
Drop mypy version pin

### DIFF
--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install mypy==0.921 types-protobuf==3.19.21
+          pip install mypy types-protobuf==3.19.21
 
       - name: Execute run_stubtest.py
         run: |
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install mypy==0.921 types-protobuf==3.19.21
+          pip install mypy types-protobuf==3.19.21
 
       - name: Run mypy
         run: |


### PR DESCRIPTION
Commit 038a5890e4f1 ("Add imports of int values to .pyi files (#225)")
removed the need for a mypy version pin, but missed one of the places
where it was pinned.