### PR TITLE
docs: Fix a few typos

### DIFF
--- a/python/phonenumbers/phonemetadata.py
+++ b/python/phonenumbers/phonemetadata.py
@@ -251,7 +251,7 @@ class PhoneMetadata(UnicodeMixin, ImmutableMixin):
 
     """
     # Lock that protects the *_available fields while they are being modified.
-    # The modificiation involves loading data from a file, so we cannot just
+    # The modification involves loading data from a file, so we cannot just
     # rely on the GIL.
     _metadata_lock = threading.Lock()
     # If a region code is a key in this dict, metadata for that region is available.

--- a/python/phonenumbers/phonenumberutil.py
+++ b/python/phonenumbers/phonenumberutil.py
@@ -649,7 +649,7 @@ def _extract_possible_number(number):
     match = _VALID_START_CHAR_PATTERN.search(number)
     if match:
         number = number[match.start():]
-        # Remove trailing non-alpha non-numberical characters.
+        # Remove trailing non-alpha non-numerical characters.
         trailing_chars_match = _UNWANTED_END_CHAR_PATTERN.search(number)
         if trailing_chars_match:
             number = number[:trailing_chars_match.start()]


### PR DESCRIPTION
There are small typos in:
- python/phonenumbers/phonemetadata.py
- python/phonenumbers/phonenumberutil.py

Fixes:
- Should read `numerical` rather than `numberical`.
- Should read `modification` rather than `modificiation`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md