### PR TITLE
Add a scheduled GitHub Action to check upstream version

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -1,0 +1,21 @@
+name: Check libphonenumbers releases
+
+on:
+  schedule:
+    - cron: '30 7,19 * * *'  # Run daily at 07:30 and 19:30
+  workflow_dispatch:
+
+jobs:
+  versioncheck:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == "daviddrysdale"
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
+      - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4
+        with:
+          python-version: 3
+      - name: Check upstream version
+        run: |
+          pip install -U pip
+          pip install requests
+          python3 tools/python/checkupstreamversion.py

--- a/tools/python/checkupstreamversion.py
+++ b/tools/python/checkupstreamversion.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+import os
+import re
+import sys
+
+import requests
+
+# Fetch the latest upstream release tag.
+try:
+    response = requests.get(
+        "https://api.github.com/repos/google/libphonenumber/releases/latest"
+    )
+    response.raise_for_status()
+except requests.RequestException as err:
+    print("Failed to connect to the GitHub API!", file=sys.stderr)
+    raise SystemExit(2) from err
+upstream_tag = response.json()["tag_name"]
+
+# Check the tag name has the expected format.
+m = re.match(r"v([\d.]+)$", upstream_tag)
+if not m:
+    print(f"Unexpected upstream tag {upstream_tag}", file=sys.stderr)
+    raise SystemExit(2)
+upstream_version = m.group(1)
+
+# Fetch the current source code version.
+init_path = os.path.join(
+    os.path.dirname(__file__), "..", "..", "python", "phonenumbers", "__init__.py"
+)
+with open(init_path, "r") as fp:
+    init_contents = fp.read()
+m = re.search(r'^__version__ = "([^"]+)"$', init_contents, re.MULTILINE)
+if not m:
+    print("Could not extract python-phonenumbers version", file=sys.stderr)
+    raise SystemExit(2)
+local_version = m.group(1)
+
+# Compare versions.
+if upstream_version == local_version:
+    print(f"Local version {local_version} matches upstream version {upstream_version}")
+    raise SystemExit(0)
+else:
+    print(
+        f"Local version {local_version} does not match upstream version {upstream_version}"
+    )
+    raise SystemExit(1)


### PR DESCRIPTION
Twice a day, a scheduled action checks the latest upstream release and compares it to the current `phonenumbers` version. The check succeeds if and only if the two versions match.

See #273 