### PR TITLE
Update README.md for description_for_number

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ PhoneNumberMatch [51,62) 703-4800500
 ```
 
 You might want to get some information about the location that corresponds to a phone number.  The
-`geocoder.area_description_for_number` does this, when possible.
+`geocoder.description_for_number` does this, when possible.
 
 ```pycon
 >>> from phonenumbers import geocoder


### PR DESCRIPTION
It looks like `area_description_for_number` is supposed to be `description_for_number` based on the example following.