### PR TITLE
Fix geocoder returning empty when a longer prefix lacks the requested language

### DIFF
--- a/python/phonenumbers/prefix.py
+++ b/python/phonenumbers/prefix.py
@@ -85,6 +85,5 @@ def _prefix_description_for_number(data, longest_prefix, numobj, lang, script=No
             name = _find_lang(data[prefix], lang, script, region)
             if name is not None:
                 return name
-            else:
-                return U_EMPTY_STRING
+            # Language not available for this prefix; try a less-specific (shorter) prefix.
     return U_EMPTY_STRING

--- a/python/tests/geocodertest.py
+++ b/python/tests/geocodertest.py
@@ -178,6 +178,29 @@ class PhoneNumberGeocoderTest(unittest.TestCase):
         # We have a geocoding prefix, but we shouldn't use it since this is not geographical.
         self.assertEqual("South Korea", description_for_number(KO_MOBILE, _ENGLISH))
 
+    def testPrefixFallsBackToShorterPrefixWhenLanguageMissing(self):
+        # Python version extra test - this has no equivalent Java test.
+        # This can occur when only a subset of sub-prefixes carry alternative-language
+        # entries for a region.
+        #
+        # Simulate: '1212' has 'en', '12123' exists only for 'de'.
+        # Asking for 'fr' on a number whose digits start with 12123 should fall back
+        # to '1212' and return the English name (since French falls back to English),
+        # not the empty string from '12123'.
+        TEST_GEOCODE_DATA['12123'] = {'de': u("TestDistrict")}
+        try:
+            # US_NUMBER3 is +1 212-812-0000; its prefix digits start with '12128' so
+            # it won't hit '12123'.  Use a fabricated number whose digits begin '12123'.
+            test_num = FrozenPhoneNumber(country_code=1, national_number=2123000000)
+            # '12123' has no 'fr', '1212' has 'en' -> French should fall back to 'NY'
+            self.assertEqual("NY", _prefix_description_for_number(
+                TEST_GEOCODE_DATA, TEST_GEOCODE_LONGEST_PREFIX, test_num, "fr"))
+            # 'de' is directly present in '12123', so German gets the detailed name
+            self.assertEqual("TestDistrict", _prefix_description_for_number(
+                TEST_GEOCODE_DATA, TEST_GEOCODE_LONGEST_PREFIX, test_num, "de"))
+        finally:
+            del TEST_GEOCODE_DATA['12123']
+
     def testCoverage(self):
         # Python version extra tests
         invalid_number = PhoneNumber(country_code=210, national_number=123456)


### PR DESCRIPTION
## Problem

`_prefix_description_for_number` (in `prefix.py`) immediately returned an
empty string when a longer (more-specific) prefix existed in the geocoding
data but did not carry an entry for the requested language.  This prevented
the loop from falling through to shorter prefixes that *do* have the language
data, causing `description_for_number` to fall back all the way to the country
name.

### Concrete example

Finnish Helsinki-area numbers (`+3589x…`) are described as `'Finland'` instead
of `'Helsinki'` when English or Finnish is requested:

```python
>>> import phonenumbers
>>> from phonenumbers import geocoder
>>> num = phonenumbers.parse("+358912345678")
>>> geocoder.description_for_number(num, "en")
'Finland'   # ← wrong; expected 'Helsinki'
>>> geocoder.description_for_number(num, "fi")
'Suomi'     # ← wrong; expected 'Helsinki'
```

**Root cause**: the production geocoding data contains a 5-digit prefix
`'35891'` with only `{'se': 'Helsingfors'}` (Swedish via the 'se' locale key),
and a 4-digit prefix `'3589'` with `{'en': 'Helsinki', 'fi': 'Helsinki',
'sv': 'Helsingfors'}`.  Because `'35891'` is the longer (more-specific) match
and is found first, the old code returned `''` without ever reaching `'3589'`.

The same defect affects a handful of other prefixes (DRC, Armenia, Italy,
Taiwan) where a sub-prefix carries an alternative-language-only entry while the
parent prefix has the common languages.

## Fix

Remove the `else: return U_EMPTY_STRING` branch so that the loop continues to
shorter prefixes when `_find_lang` returns `None`.  The function still returns
`U_EMPTY_STRING` at the end of the loop when no prefix at all has usable data.

```diff
-            if name is not None:
-                return name
-            else:
-                return U_EMPTY_STRING
+            if name is not None:
+                return name
+            # Language not available for this prefix; try a less-specific (shorter) prefix.
```

## Tests

A regression test (`testPrefixFallsBackToShorterPrefixWhenLanguageMissing`)
is added to `geocodertest.py`.  It injects a synthetic longer-prefix entry
into the test geodata (one that has only German) and verifies that a French
request correctly falls through to the shorter prefix's English data.  All
280 existing tests continue to pass.

---

This pull request was prepared with the assistance of AI, under my direction and review.