### PR TITLE
Avoid catastrophic backtracking in the phone-context domainname check

### DIFF
--- a/python/phonenumbers/phonenumberutil.py
+++ b/python/phonenumbers/phonenumberutil.py
@@ -382,8 +382,8 @@ _RFC3966_GLOBAL_NUMBER_DIGITS_PATTERN = re.compile(_RFC3966_GLOBAL_NUMBER_DIGITS
 # Regular expression of valid domainname for the phone-context parameter,
 # following the syntax defined in RFC3966.
 _ALPHANUM = _VALID_ALPHA + _DIGITS
-_RFC3966_DOMAINLABEL = "[" + _ALPHANUM + "]+((\\-)*[" + _ALPHANUM + "])*"
-_RFC3966_TOPLABEL = "[" + _VALID_ALPHA + "]+((\\-)*[" + _ALPHANUM + "])*"
+_RFC3966_DOMAINLABEL = "[" + _ALPHANUM + "]+(\\-+[" + _ALPHANUM + "]+)*"
+_RFC3966_TOPLABEL = "[" + _VALID_ALPHA + "]+(\\-+[" + _ALPHANUM + "]+)*"
 _RFC3966_DOMAINNAME = "^(" + _RFC3966_DOMAINLABEL + "\\.)*" + _RFC3966_TOPLABEL + "\\.?$"
 _RFC3966_DOMAINNAME_PATTERN = re.compile(_RFC3966_DOMAINNAME)
 

--- a/python/tests/phonenumberutiltest.py
+++ b/python/tests/phonenumberutiltest.py
@@ -2010,11 +2010,11 @@ class PhoneNumberUtilTest(TestMetadataTestCase):
         # ([alnum]+((\-)*[alnum])* per label) made CPython's backtracking
         # engine spend ~50s on this input before failing.
         evil_context = "aa." * 25 + "aa!"
-        start = time.monotonic()
+        start = time.time()
         self.assertRaises(NumberParseException,
                           phonenumbers.parse,
                           "tel:253-0000;phone-context=" + evil_context, "US")
-        self.assertLess(time.monotonic() - start, 10)
+        self.assertLess(time.time() - start, 10)
 
         nzNumber = PhoneNumber(country_code=64, national_number=64123456)
         self.assertEqual(nzNumber, phonenumbers.parse("64(0)64123456", "NZ"))

--- a/python/tests/phonenumberutiltest.py
+++ b/python/tests/phonenumberutiltest.py
@@ -18,6 +18,7 @@
 # limitations under the License.
 import sys
 import pickle
+import time
 
 import phonenumbers
 from phonenumbers import PhoneNumber, PhoneMetadata
@@ -2003,6 +2004,17 @@ class PhoneNumberUtilTest(TestMetadataTestCase):
                          phonenumbers.parse("tel:253-0000;isub=12345;phone-context=www.google.com", "US"))
         self.assertEqual(US_LOCAL_NUMBER,
                          phonenumbers.parse("tel:2530000;isub=12345;phone-context=1234.com", "US"))
+
+        # A long phone-context domain with an ambiguous label structure must
+        # be rejected quickly. The old domainname pattern
+        # ([alnum]+((\-)*[alnum])* per label) made CPython's backtracking
+        # engine spend ~50s on this input before failing.
+        evil_context = "aa." * 25 + "aa!"
+        start = time.monotonic()
+        self.assertRaises(NumberParseException,
+                          phonenumbers.parse,
+                          "tel:253-0000;phone-context=" + evil_context, "US")
+        self.assertLess(time.monotonic() - start, 10)
 
         nzNumber = PhoneNumber(country_code=64, national_number=64123456)
         self.assertEqual(nzNumber, phonenumbers.parse("64(0)64123456", "NZ"))


### PR DESCRIPTION
The per-label pattern in `_RFC3966_DOMAINNAME_PATTERN` is ambiguous:

```python
_RFC3966_DOMAINLABEL = "[" + _ALPHANUM + "]+((\\-)*[" + _ALPHANUM + "])*"
```

An alphanumeric run can be split between the leading `+` and the repeating group in many equivalent ways, so when the overall match fails, CPython's backtracking engine re-explores the suffix once per split — exponential in the number of labels. A 98-character input through the public `parse()` locks the thread for ~50 s on phonenumbers 9.0.37:

```python
inp = "tel:1;phone-context=" + "aa." * 25 + "aa!"
phonenumbers.parse(inp, "US")   # ~50s before raising NumberParseException
```

This rewrites the label as `[alnum]+(\\-+[alnum]+)*` — same accepted language (alnum runs separated by one or more hyphens, still no leading/trailing hyphen), but each position has exactly one way to match. The input above now fails validation in under a millisecond.

Also adds a regression test asserting the evil phone-context is rejected quickly (it used to take ~50 s, so the 10 s bound in the test has plenty of margin).

The same change is proposed upstream in google/libphonenumber — the JS port mirrors this pattern and is affected too (~147 s on 93 chars in V8); Java's own matcher prunes this shape efficiently and isn't practically affected.

Full test suite (`make -C tools/python test`, 308 tests) and lint pass locally.